### PR TITLE
Automatically populate data properties with passed parameters when onMount() isn't defined

### DIFF
--- a/models/concerns/OnMountConcern.cfc
+++ b/models/concerns/OnMountConcern.cfc
@@ -25,13 +25,30 @@ component accessors="true" singleton {
 				);
 		} else {
 			/**
-			 * Use setter population to populate our component.
+			 * Use scope population to populate our component.
 			 */
+
+			// check datatypes parameters and throw error if not string, boolean, numeric, date, array, or struct
+			for( var paramKey IN arguments.parameters.keyArray() ){
+				if( !isSimpleValue( arguments.parameters[ paramKey ] ) 
+					&& !isArray( arguments.parameters[ paramKey ] ) 
+					&& !isStruct( arguments.parameters[ paramKey ] )
+				){
+					throw( 
+						type 		= "MissingOnMount", 
+						message 	= "The wire does NOT have onMount() function and the paramaters passed contain a 
+									  data type other than a string, boolean, numeric, date, array, or struct and cannot 
+									  be automatically inserted into the data properties. To avoid this error create an 
+									  onMount() method to handle incoming paramaters" 
+					);
+				}
+			}
+
+			// if parameters passed in are string, boolean, numeric, date, array, or struct insert into variables.data
 			getPopulator().populateFromStruct(
-				target: this,
-				trustedSetter: true,
+				target: comp.getParent(),
 				memento: arguments.parameters,
-				excludes: ""
+				scope: "variables.data"
 			);
 		}
 

--- a/models/concerns/OnMountConcern.cfc
+++ b/models/concerns/OnMountConcern.cfc
@@ -30,9 +30,13 @@ component accessors="true" singleton {
 
 			// check datatypes parameters and throw error if not string, boolean, numeric, date, array, or struct
 			for( var paramKey IN arguments.parameters.keyArray() ){
-				if( !isSimpleValue( arguments.parameters[ paramKey ] ) 
-					&& !isArray( arguments.parameters[ paramKey ] ) 
-					&& !isStruct( arguments.parameters[ paramKey ] )
+				if( ( 
+						!isSimpleValue( arguments.parameters[ paramKey ] ) 
+						&& !isArray( arguments.parameters[ paramKey ] ) 
+						&& !isStruct( arguments.parameters[ paramKey ] ) 
+					)
+					|| isObject( arguments.parameters[ paramKey ] )
+					|| isCustomFunction( arguments.parameters[ paramKey ] )
 				){
 					throw( 
 						type 		= "MissingOnMount", 

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -1113,6 +1113,88 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( event.getRenderedContent() ).notToContain( "<!-- CBWIRE Scripts -->" );
 			} );
 		} );
+	
+		describe( "Component without onMount", function(){
+			
+			it( "can render with no parameters passed", function() {
+				var cbwireService = prepareMock( getInstance( "CBWIREService@cbwire" ) );
+				var result = cbwireService.wire( "tests.templates.withoutOnMountEvent" );
+				expect( result ).toContain( "COMPLETED-PROCESSING" );
+			} );
+			
+			it( "can render with empty struct parameters passed", function() {
+				var cbwireService = prepareMock( getInstance( "CBWIREService@cbwire" ) );
+				var result = cbwireService.wire( "tests.templates.withoutOnMountEvent", {} );
+				expect( result ).toContain( "COMPLETED-PROCESSING" );
+			} );
+
+			it( "throws MissingOnMount when parameters contains value of datatype other than string, boolean, numeric, date, array, or struct (java object)", function(){
+				var cbwireService = prepareMock( getInstance( "CBWIREService@cbwire" ) );
+				var javaObj = createObject( "java", "java.lang.StringBuilder" ).init( "" );
+				expect( function() {
+						var result = cbwireService.wire( 
+								"tests.templates.withoutOnMountEvent", 
+								{ 
+									"testString" : "String Value",
+									"javaObj" : javaObj
+								} 
+							);
+				}).toThrow( type="MissingOnMount" );  
+			} );
+
+			it( "throws MissingOnMount when parameters contains value of datatype other than string, boolean, numeric, date, array, or struct (cfcomponent)", function(){
+				var cbwireService = prepareMock( getInstance( "CBWIREService@cbwire" ) );
+				var basicCFComponent = new tests.templates.basicCFComponent();
+				expect( function() {
+						var result = cbwireService.wire( 
+								"tests.templates.withoutOnMountEvent", 
+								{ 
+									"testString" : "String Value",
+									"basicCFComponent" : basicCFComponent
+								} 
+							);
+				}).toThrow( type="MissingOnMount" );  
+			} );
+
+			it( "throws MissingOnMount when parameters contains value of datatype other than string, boolean, numeric, date, array, or struct (user defined function)", function(){
+				var cbwireService = prepareMock( getInstance( "CBWIREService@cbwire" ) );
+				var myUDF = function(){
+					return "Hello Testbox!";
+				};
+				expect( function() {
+						var result = cbwireService.wire( 
+								"tests.templates.withoutOnMountEvent", 
+								{ 
+									"testString" : "String Value",
+									"myUDF" : myUDF
+								} 
+							);
+				}).toThrow( type="MissingOnMount" );  
+			} );
+
+			it( "can render with parameters of types string, boolean, numeric, date, array, or struct and merge with pre-existing data properties", function() {
+				var cbwireService = prepareMock( getInstance( "CBWIREService@cbwire" ) );
+				var result = cbwireService.wire( 
+					"tests.templates.withoutOnMountEvent", 
+				    { 
+						"testString" : "String Value", 
+						"testArray" : [ "value1", "value2", "value3" ], 
+						"testStruct" : { "keyOne" : 9, "keyTwo" : true, "keyThree" : "Test struct key three text" }, 
+						"testNumber" : 5678, 
+						"testBoolean" : true, 
+						"testDate" : now()
+					} 
+				);
+				expect( result ).toContain( 'variables.data.testString = "String Value"' );
+				expect( result ).toContain( "variables.data.preDefinedNumber = 1234" );
+				expect( result ).toContain( "variables.data.testNumber = 5678" );
+				expect( result ).toContain( 'variables.testString = "String Value"' );
+				expect( result ).toContain( "variables.preDefinedNumber = 1234" );
+				expect( result ).toContain( "variables.testNumber = 5678" );
+				expect( result ).toContain( "COMPLETED-PROCESSING" );
+			} );
+		
+		});
 	}
 
 	private function renderInitial( comp ) {

--- a/test-harness/tests/templates/basicCFComponent.cfc
+++ b/test-harness/tests/templates/basicCFComponent.cfc
@@ -1,0 +1,11 @@
+component displayname="basicCFComponent" output="false" { 
+    
+    public basicCFComponent function init() {
+        return this;
+    }
+
+    public string function helloTestBox(){
+        return "<h1>Hello Testbox!</h1>"
+    }
+
+}

--- a/test-harness/tests/templates/withoutOnMountEvent.cfm
+++ b/test-harness/tests/templates/withoutOnMountEvent.cfm
@@ -1,0 +1,26 @@
+<cfscript>
+    data = {
+        "preDefinedString" : "Pre Defined String Value",
+        "preDefinedNumber" : 1234
+    };
+</cfscript>
+
+<cfoutput>
+    <div>
+        <h1>Test Wire Component Without OnMount() Event</h1>
+
+        <h5>Output from variables.data</h5>
+        <cfloop item="key" collection=#variables.data# >
+             variables.data.#key# = #serializeJSON( variables.data[key] )#<br/>
+        </cfloop>
+        <hr>
+
+        <h5>Output from variables</h5>
+        <cfloop item="key" collection=#variables.data# >
+             variables.#key# = #serializeJSON( variables[key] )#<br/>
+        </cfloop>
+        <hr>
+        
+        COMPLETED-PROCESSING
+    </div>
+</cfoutput>


### PR DESCRIPTION
Building on box products' love of conventions, if onMount() does not exist, we check that each parameter is a string, boolean, numeric, date, array, or struct and if they are we populate the component using scope population instead of setters. 

#131 