### PR TITLE
Pass params from wire function to TestComponentSpec.

### DIFF
--- a/models/BaseWireTest.cfc
+++ b/models/BaseWireTest.cfc
@@ -6,10 +6,10 @@ component extends="coldbox.system.testing.BaseTestCase" {
 	 * @componentName Name of cbwire component.
 	 * @return TestComponentSpec
 	 */
-	function wire( required componentName ){
+	function wire( required componentName, params = {} ){
 		return getInstance(
 			name = "TestComponentSpec@cbwire",
-			initArguments = { componentName : arguments.componentName }
+			initArguments = { componentName : arguments.componentName, parameters : arguments.params }
 		);
 	}
 

--- a/models/TestComponentSpec.cfc
+++ b/models/TestComponentSpec.cfc
@@ -104,7 +104,8 @@ component extends="testbox.system.BaseSpec" accessors="true" {
 					computedProperties[ key ] = value;
 				} );
 			}
-			var rendering = cbwireComponent.mount( getParameters() ).renderIt();
+			cbwireComponent.onMount( params = getParameters() );
+			var rendering = cbwireComponent.renderIt();
 			setRendering( rendering );
 			return rendering;
 		}


### PR DESCRIPTION
This PR fix two issues with tests:

* In tests if you pass arguments to the wire function, there are not passed to the test component. 

* The test component uses `mount` and throws a MissingMethod exception. Also, it links with `.renderIt()` but `onMount` doesn't return the object, so I put in two sentences. 

