### PR TITLE
Add @Module syntax support for V4

### DIFF
--- a/models/CBWIREController.cfc
+++ b/models/CBWIREController.cfc
@@ -11,6 +11,9 @@ component singleton {
 
     // Inject module settings
     property name="moduleSettings" inject="coldbox:modulesettings:cbwire";
+    
+	// Inject module service
+	property name="moduleService" inject="coldbox:moduleService";
 
     // Inject SingleFileComponentBuilder
     property name="singleFileComponentBuilder" inject="SingleFileComponentBuilder@cbwire";
@@ -170,6 +173,16 @@ component singleton {
             local.fullComponentPath = "wires." & local.fullComponentPath;
         }
         
+		if ( find( "@", local.fullComponentPath ) ) {
+			// This is a module reference, find in our module
+			var params = listToArray( local.fullComponentPath, "@" );
+			if ( params.len() != 2 ) {
+				throw( type="ModuleNotFound", message = "CBWIRE cannot locate the module or component using '" & local.fullComponentPath & "'." );
+			}
+            // modify local.fullComponentPath to full path for module
+            local.fullComponentPath = getModuleComponentPath( params[ 1 ], params[ 2 ] );
+		}
+
         try {
             // Attempt to create an instance of the component
             return variables.wirebox.getInstance(local.fullComponentPath);
@@ -192,6 +205,25 @@ component singleton {
             throw("ApplicationException", "Unable to instantiate component '#arguments.name#'. Detail: #e.message#");
         }
     }
+
+	/**
+	 * Returns the full dot notation path to a modules component.
+	 *
+	 * @path String | Name of the cbwire component.
+	 * @module String | Name of the module to look for wire in.
+	 */
+	private function getModuleComponentPath( path, module ) {
+		var moduleConfig = moduleService.getModuleConfigCache();
+		if ( !moduleConfig.keyExists( module ) ) {
+			throw( type="ModuleNotFound", message = "CBWIRE cannot locate the module '" & arguments.module & "'.")
+		}
+
+		// if there is a dot in the path, then we are referencing a folder within a module otherwise use the default wire location.
+		var moduleRegistry = moduleService.getModuleRegistry();
+		return arguments.path contains "." ?
+			moduleRegistry[ module ].invocationPath & "." & module & "." & arguments.path :
+			moduleRegistry[ module ].invocationPath & "." & module & "." & getWiresLocation() & "." & arguments.path;
+	}
 
     /**
      * Returns the ColdBox RequestContext object.

--- a/test-harness/anotherFolder/OutsideFolderComponent.cfm
+++ b/test-harness/anotherFolder/OutsideFolderComponent.cfm
@@ -1,7 +1,11 @@
 <cfscript>
+    //@startWire
+
     data = {
         "title": "outside component"
     }
+    
+    //@endWire
 </cfscript>
 
 <cfoutput>

--- a/test-harness/box.json
+++ b/test-harness/box.json
@@ -1,33 +1,35 @@
 {
-    "name": "Tester",
-    "version": "0.0.0",
-    "slug": "tester",
-    "private": true,
-    "description": "",
-    "dependencies": {
-        "coldbox": "^6",
-        "cbvalidation": "^4.3.0+24",
-        "cbi18n": "^3.2.0+12"
+    "name":"Tester",
+    "version":"0.0.0",
+    "slug":"tester",
+    "private":true,
+    "description":"",
+    "dependencies":{
+        "coldbox":"^6",
+        "cbvalidation":"^4.3.0+24",
+        "cbi18n":"^3.2.0+12",
+        "cbcsrf":"^3.1.0+16"
     },
-    "devDependencies": {
-        "testbox": "^5",
-        "route-visualizer": "^1.4.0+24"
+    "devDependencies":{
+        "testbox":"^5",
+        "route-visualizer":"^1.4.0+24"
     },
-    "installPaths": {
-        "coldbox": "coldbox/",
-        "testbox": "testbox/",
-        "cbvalidation": "modules/cbvalidation/",
-        "route-visualizer": "modules/route-visualizer/",
-        "cbi18n": "modules/cbi18n/"
+    "installPaths":{
+        "coldbox":"coldbox/",
+        "testbox":"testbox/",
+        "cbvalidation":"modules/cbvalidation/",
+        "route-visualizer":"modules/route-visualizer/",
+        "cbi18n":"modules/cbi18n/",
+        "cbcsrf":"modules/cbcsrf/"
     },
-    "testbox": {
-        "runner": "http://localhost:60299/tests/runner.cfm"
+    "testbox":{
+        "runner":"http://localhost:60299/tests/runner.cfm"
     },
-    "scripts": {
-        "cfpm": "echo '\".engine/adobe2021/WEB-INF/cfusion/bin/cfpm.sh\"' | run",
-        "cfpm:install2021": "echo '\".engine/adobe2021/WEB-INF/cfusion/bin/cfpm.sh\" install ${1}' | run",
-        "cfpm:install2023": "echo '\".engine/adobe2023/WEB-INF/cfusion/bin/cfpm.sh\" install ${1}' | run",
-        "install:2021": "run-script cfpm:install2021 zip,mysql,debugger",
-        "install:2023": "run-script cfpm:install2023 zip,mysql,debugger"
+    "scripts":{
+        "cfpm":"echo '\".engine/adobe2021/WEB-INF/cfusion/bin/cfpm.sh\"' | run",
+        "cfpm:install2021":"echo '\".engine/adobe2021/WEB-INF/cfusion/bin/cfpm.sh\" install ${1}' | run",
+        "cfpm:install2023":"echo '\".engine/adobe2023/WEB-INF/cfusion/bin/cfpm.sh\" install ${1}' | run",
+        "install:2021":"run-script cfpm:install2021 zip,mysql,debugger",
+        "install:2023":"run-script cfpm:install2023 zip,mysql,debugger"
     }
 }

--- a/test-harness/modules_app/testingmodule/myComponents/NestedModuleComponent.cfm
+++ b/test-harness/modules_app/testingmodule/myComponents/NestedModuleComponent.cfm
@@ -1,7 +1,11 @@
 <cfscript>
+    //@startWire
+
     data = {
         "title": "Nested module component"
     }
+    
+    //@endWire
 </cfscript>
 
 <cfoutput>

--- a/test-harness/modules_app/testingmodule/wires/NestedModuleDefaultComponent.cfm
+++ b/test-harness/modules_app/testingmodule/wires/NestedModuleDefaultComponent.cfm
@@ -1,7 +1,11 @@
 <cfscript>
+    //@startWire
+    
     data = {
         "title": "Nested module component using default wires location"
     }
+
+    //@endWire
 </cfscript>
 
 <cfoutput>

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -821,6 +821,28 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 expect( result.trim() ).toBe( "</div>" );
             } );
 
+			it( "can render component from ./wires folder using wire()", function() {
+				var result = cbwireController.wire( "TestComponent" );
+				expect( result ).toContain( "Title: CBWIRE Rocks!" );
+			} );
+
+			it( "can render component from nested folder using wire()", function() {
+				var result = cbwireController.wire( "wires.nestedComponent.NestedFolderComponent" );
+				expect( result ).toContain( "Nested folder component" );
+			} );
+
+			it( "throws error if it's unable to find a module component", function() {
+				expect( function() {
+					var result = cbwireController.wire( "missing@someModule" );
+				} ).toThrow( type="ModuleNotFound" );  
+			} );
+
+			it( "can render component from nested module using default wires location", function() {
+				var result = cbwireController.wire( "NestedModuleDefaultComponent@testingmodule" );
+				expect( result ).toContain( "Nested module component using default wires location" );
+			} );
+
+
         });
 
         describe( "Preprocessors", function() {

--- a/test-harness/wires/nestedComponent/NestedFolderComponent.cfm
+++ b/test-harness/wires/nestedComponent/NestedFolderComponent.cfm
@@ -1,7 +1,11 @@
 <cfscript>
+    //@startWire
+
     data = {
         "title": "Nested folder component"
     }
+    
+    //@endWire
 </cfscript>
 
 <cfoutput>


### PR DESCRIPTION
Added `@Module` syntax support back for Version 4. Enables wires to be located in a module and run from anywhere in your application.

Example:

`#wire( "myWire@myModule" )#`

CBWire will translate the wire path to:

`/modules_app/myModule/wires/myWire` 