### PR TITLE
Add additional validation check in _hydrate() loop over data properties and tests

### DIFF
--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -585,7 +585,7 @@ component output="true" {
             Provide file uploads to view
         */
         variables.data.each( function( key, value ) {
-            if ( isArray( arguments.value ) && arguments.value.len() && arguments.value[ 1 ] contains "fileupload:" ) {
+            if ( isArray( arguments.value ) && arguments.value.len() && isSimpleValue( arguments.value[ 1 ] ) && arguments.value[ 1 ] contains "fileupload:" ) {
                 // This property is holding an array of file uploads.
                 value.each( function( uuid, index ) {
                     local.fileUpload = getInstance( dsl="FileUpload@cbwire" ).load(

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -253,6 +253,21 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 }
             } );
 
+            it( "should handle a data property that is an array of structs", function(){
+                dataWithStructComponent = getInstance("wires.dataWithStructWire")._withEvent( getRequestContext( ) );
+                prepareMock( dataWithStructComponent );
+                // add aditional states
+                dataWithStructComponent.onMount();
+                dataWithStructComponent.addState( "IA", "Iowa" );
+                dataWithStructComponent.addState( "CA", "California" );
+                // verify data struct read and write without errors
+                var structViewContent = dataWithStructComponent.view("wires.dataWithStructWire");
+                expect(structViewContent).toInclude("Number Of States In data.states: 6");
+                expect(structViewContent).toInclude("IA : Iowa");
+                expect(structViewContent).toInclude("CA : California");
+
+            } );
+
         });
 
         describe("Incoming Requests", function() {
@@ -651,6 +666,30 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 expect( snapshot.data.modules[ 2 ] ).toBe( "CBORM" );
             } );
 
+            it( "should handle incoming reqeust when a data property contains an array of structs", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "dataWithStructWire",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {
+                        "title": "CBWIRE Rocks!",
+                        "states": [
+                            { "name" : "Maryland", "abr" : "MD" },
+                            { "name" : "Virginia", "abr" : "VA" },
+                            { "name" : "Florida", "abr" : "FL" },
+                            { "name" : "Wyoming", "abr" : "WY" }
+                        ]
+                      },
+                    calls = [],
+                    updates = {
+                        "title": "CBWIRE Slaps!"
+                    }
+                );
+                var response = cbwireController.handleRequest( payload, event );
+                expect( response.components[1].effects.html ).toInclude( "CBWIRE Slaps!" );
+            } );
         } );
 
         describe("File Uploads", function() {

--- a/test-harness/wires/dataWithStructWire.cfc
+++ b/test-harness/wires/dataWithStructWire.cfc
@@ -1,0 +1,20 @@
+component extends="cbwire.models.Component" {
+
+    data = [
+        "title": "CBWIRE Rocks!",
+        "states": []
+    ];
+
+    function addState( abr, name ){
+        data.states.append( { "name" : name, "abr" : abr } );
+    }
+
+    function onMount( params, event, rc, prc ) {
+        // Initialize some states
+        data.states.append( { "name" : "Maryland", "abr" : "MD" } );
+        data.states.append( { "name" : "Virginia", "abr" : "VA" } );
+        data.states.append( { "name" : "Florida", "abr" : "FL" } );
+        data.states.append( { "name" : "Wyoming", "abr" : "WY" } );
+    }
+
+}

--- a/test-harness/wires/dataWithStructWire.cfm
+++ b/test-harness/wires/dataWithStructWire.cfm
@@ -1,0 +1,14 @@
+<cfoutput>
+    <div>
+        <div>#args.title#</div>
+        <h1>States</h1>
+        <p>Number Of States In data.states: #states.len()#</p>
+        <cfif states.len() >
+            <ul>
+                <cfloop index="currentIndex" item="currentState" array="#states#"> 
+                    <li>#currentState.abr# : #currentState.name#</li>
+                </cfloop>
+            </ul>
+        </cfif>
+    </div>
+</cfoutput>


### PR DESCRIPTION
Fixes error that breaks /cbwire/update ajax calls. When a data property has an array of structs the wire is initially rendered however all subsequent updates fail when the component.cfc _hydrate() method is run and it looks for a file upload data property.

Test Results before modification to component.cfc _hydrate() method:
<img width="1300" alt="Screenshot 2024-06-21 at 11 04 49 PM" src="https://github.com/coldbox-modules/cbwire/assets/1075170/fe5b0d4d-03e3-41f0-8c87-be2cd1f9f209">