### PR TITLE
Locked data props

### DIFF
--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -809,7 +809,7 @@ component output="true" {
     /**
      * Validate if key being updated is a locked property.
      *
-     * @key struct | A struct or string containing the key being updated.
+     * @key string | the data property key being updated.
      *
      * @return void
      */
@@ -817,9 +817,8 @@ component output="true" {
 		if( !variables.keyExists("locked") ) return;
 		if( isArray( variables.locked ) && arrayFindNoCase( variables.locked, arguments.key ) )
 			throw( type="CBWIREException", message="Locked properties cannot be updated." );
-		else if ( isSimpleValue( variables.locked ) && arguments.key == variables.locked )
+		else if ( isSimpleValue( variables.locked ) && listToArray(variables.locked).find( arguments.key ) )
 			throw( type="CBWIREException", message="Locked properties cannot be updated." );
-
 	}
 
     /**

--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -35,7 +35,7 @@ component output="true" {
 
     /**
      * Constructor
-     * 
+     *
      * @return The initialized component instance.
      */
     function init() {
@@ -46,7 +46,7 @@ component output="true" {
      * Initializes the component after dependency injection, setting a unique ID if not already set.
      * This method should be called by any extending component's init method if overridden.
      * Extending components should invoke super.init() to ensure the base initialization is performed.
-     * 
+     *
      * @return The initialized component instance.
      */
     function onDIComplete() {
@@ -71,8 +71,8 @@ component output="true" {
         variables._renderedContent = "";
         variables._scripts = [:];
         variables._assets = [:];
-        
-        /* 
+
+        /*
             Cache the component's meta data on initialization
             for fast access where needed.
         */
@@ -84,11 +84,11 @@ component output="true" {
         _prepareDataProperties();
 
         /*
-            Prep our computed properties for caching 
+            Prep our computed properties for caching
         */
         _prepareComputedProperties();
-        
-        /* 
+
+        /*
             Prep generated getters and setters for data properties
         */
         _prepareGeneratedGettersAndSetters();
@@ -98,17 +98,17 @@ component output="true" {
         */
         _prepareIsolation();
 
-        /* 
+        /*
             Prep for lazy loading
         */
         _prepareLazyLoading();
 
-        /* 
+        /*
             Prep listeners
         */
         _prepareListeners();
 
-        /* 
+        /*
             Fire onBoot lifecycle method
             if it exists
         */
@@ -133,7 +133,7 @@ component output="true" {
 
     /**
      * Returns the CBWIRE Controller
-     * 
+     *
      * @return CBWIREController
      */
     function getCBWIREController(){
@@ -142,7 +142,7 @@ component output="true" {
 
     /**
      * renderIt left for backwards compatibility.
-     * 
+     *
      * @return string
      */
     function renderIt() {
@@ -246,7 +246,7 @@ component output="true" {
     /**
      * Captures a dispatch to be executed later
      * by the browser.
-     * 
+     *
      * @event string | The event to dispatch.
      * @params | The parameters to pass to the listeners.
      *
@@ -264,8 +264,8 @@ component output="true" {
      *
      * @event string | The event to dispatch.
      * @params struct | The parameters to pass to the method.
-     * 
-     * @return void 
+     *
+     * @return void
      */
     function dispatchSelf( event, params = [:] ) {
        local.params = _parseDispatchParams( arguments.params );
@@ -275,11 +275,11 @@ component output="true" {
 
     /**
      * Dispatches a event to another component
-     * 
+     *
      * @to string | The component to dispatch to.
      * @event string | The method to dispatch.
      * @params struct | The parameters to pass to the method.
-     * 
+     *
      * @return void
      */
     function dispatchTo( to, event, params = [:]) {
@@ -292,7 +292,7 @@ component output="true" {
      * Instantiates a CBWIRE component, mounts it,
      * and then calls its internal onRender() method.
      *
-     * This is nearly identical to the wire method defined 
+     * This is nearly identical to the wire method defined
      * in the CBWIREController component, but it is intended
      * to provide the wire() method when including nested components
      * and provides tracking of the child.
@@ -320,8 +320,8 @@ component output="true" {
             local.children = local.incomingPayload.snapshot.memo.children;
             // Are we trying to render a child that has already been rendered?
             if ( isStruct( local.children ) && local.children.keyExists( arguments.key ) ) {
-    
-                local.componentTag = local.children[ arguments.key ][1]; 
+
+                local.componentTag = local.children[ arguments.key ][1];
                 local.componentId = local.children[ arguments.key ][2];
                 // Re-track the rendered child
                 variables._children.append( {
@@ -376,7 +376,7 @@ component output="true" {
 
     /**
      * Provides cbvalidation method to be used in actions and views.
-     * 
+     *
      * @return ValidationResult
      */
     function validate( target, fields, constraints, locale, excludeFields, includeFields, profiles ){
@@ -389,8 +389,8 @@ component output="true" {
     /**
      * Provides cbvalidation method to be used in actions and views,
      * throwing an exception if validation fails.
-     * 
-     * 
+     *
+     *
      * @throws ValidationException
      */
     function validateOrFail(){
@@ -402,7 +402,7 @@ component output="true" {
 
     /**
      * Returns true if the validation result has errors.
-     * 
+     *
      * @return boolean
      */
     function hasErrors() {
@@ -411,7 +411,7 @@ component output="true" {
 
     /**
      * Returns true if a specific property has errors.
-     * 
+     *
      * @return boolean
      */
     function hasError( prop ) {
@@ -420,7 +420,7 @@ component output="true" {
 
     /**
      * Returns array of ValidationError objects containing all of theerrors.
-     * 
+     *
      * @return array
      */
     function getErrors() {
@@ -429,7 +429,7 @@ component output="true" {
 
     /**
      * Returns the first error message for a given field.
-     * 
+     *
      * @return string
      */
     function getError( prop ) {
@@ -442,7 +442,7 @@ component output="true" {
 
     /**
      * Returns true if property passes validation.
-     * 
+     *
      * @return boolean
      */
     function validates( prop ) {
@@ -452,8 +452,8 @@ component output="true" {
     /**
      * Resets a data property to it's initial value.
      * Can be used to reset all data properties, a single data property, or an array of data properties.
-     * 
-     * @return 
+     *
+     * @return
      */
     function reset( property ){
         if ( isNull( arguments.property ) ) {
@@ -475,7 +475,7 @@ component output="true" {
 
     /**
      * Resets all data properties except the ones specified.
-     * 
+     *
      * @return void
      */
     function resetExcept( property ){
@@ -508,9 +508,9 @@ component output="true" {
     }
 
     /**
-     * Provide ability to return and execute Javascript 
+     * Provide ability to return and execute Javascript
      * in the browser.
-     * 
+     *
      * @return void
      */
     function js( code ) {
@@ -519,11 +519,11 @@ component output="true" {
 
     /**
      * Streams content to the client.
-     * 
+     *
      * @target string | The target to stream to.
      * @content string | The content to stream.
      * @replace boolean | Whether to replace the content.
-     * 
+     *
      * @return void
      */
     function stream( target, content, replace ) output="true"{
@@ -558,7 +558,7 @@ component output="true" {
      * Provides a placeholder that is used when lazy loading components.
      * This method returns an empty string. Override this method in your
      * component to provide a custom placeholder.
-     * 
+     *
      * @return string
      */
     function placeholder() {
@@ -566,14 +566,14 @@ component output="true" {
     }
 
     /**
-     * Built in action that does nothing but causes the template 
+     * Built in action that does nothing but causes the template
      * to re-render on subsequent requests.
-     * 
+     *
      * @return void
      */
     function $refresh() {}
 
-    /* 
+    /*
         ==================================================================
         Internal API
         ==================================================================
@@ -581,7 +581,7 @@ component output="true" {
 
     /**
      * Returns the id of the component.
-     * 
+     *
      * @return string
      */
     function _getId() {
@@ -590,7 +590,7 @@ component output="true" {
 
     /**
      * Passes a reference to the parent of a child component.
-     * 
+     *
      * @return Component
      */
     function _withParent( parent ) {
@@ -602,7 +602,7 @@ component output="true" {
      * Passes the path of the component.
      *
      * @path string | The path of the component.
-     * 
+     *
      * @return Component
      */
     function _withPath( path ) {
@@ -612,7 +612,7 @@ component output="true" {
 
     /**
      * Passes the current event into our component.
-     * 
+     *
      * @return Component
      */
     function _withEvent( event ) {
@@ -622,7 +622,7 @@ component output="true" {
 
     /**
      * Passes in incoming payload to the component
-     * 
+     *
      * @return Component
      */
     function _withIncomingPayload( payload ) {
@@ -636,7 +636,7 @@ component output="true" {
      *
      * @params struct | The parameters to be passed to the component.
      * @lazy boolean | (Optional) A boolean value indicating whether the component should be lazily loaded. Default is false.
-     * 
+     *
      * @return Component The updated component with the specified parameters.
      */
     function _withParams( params, lazy = false ) {
@@ -653,11 +653,11 @@ component output="true" {
 
         try {
             // Fire onMount if it exists
-            onMount( 
+            onMount(
                 event=variables._event,
                 rc=variables._event.getCollection(),
-                prc=variables._event.getPrivateCollection(),    
-                params=arguments.params         
+                prc=variables._event.getPrivateCollection(),
+                params=arguments.params
             );
         } catch ( any e ) {
             throw( type="CBWIREException", message="Failure when calling onMount(). #e.message#" );
@@ -671,7 +671,7 @@ component output="true" {
      * on subsequent requests.
      *
      * @key string | The key to be used to identify the component.
-     * 
+     *
      * @return Component
      */
     function _withKey( key ) {
@@ -681,9 +681,9 @@ component output="true" {
 
     /**
      * Passes a lazy load flag to the component.
-     * 
+     *
      * @lazy boolean | A boolean value indicating whether the component should be lazily loaded.
-     * 
+     *
      * @return Component
      */
     function _withLazy( lazy ) {
@@ -694,9 +694,9 @@ component output="true" {
 
     /**
      * Hydrate the component
-     * 
+     *
      * @componentPayload struct | A struct containing the payload to hydrate the component with.
-     * 
+     *
      * @return void
      */
     function _hydrate( componentPayload ) {
@@ -754,19 +754,21 @@ component output="true" {
 
     /**
      * Apply updates to the component
-     * 
+     *
      * @updates struct | A struct containing the updates to apply to the component.
-     * 
+     *
      * @return void
      */
     function _applyUpdates( updates ) {
         if ( !updates.count() ) return;
-        // Capture old values 
+        // Capture old values
         local.oldValues = duplicate( data );
         // Array to track which array props were updated
         local.updatedArrayProps = [];
         // Loop over the updates and apply them
         arguments.updates.each( function( key, value ) {
+			// validate if key is locked
+			_validateLockedProperty( key );
 
             // Check if we should trim if simple value
             if ( isSimpleValue( arguments.value ) && shouldTrimStringValues() ) {
@@ -791,7 +793,7 @@ component output="true" {
                 }
             }
         } );
-        
+
         local.updatedArrayProps.each( function( prop ) {
             variables.data[ arguments.prop ] = variables.data[ arguments.prop ].filter( function( value ) {
                 return arguments.value != "__rm__";
@@ -805,10 +807,26 @@ component output="true" {
     }
 
     /**
+     * Validate if key being updated is a locked property.
+     *
+     * @key struct | A struct or string containing the key being updated.
+     *
+     * @return void
+     */
+	function _validateLockedProperty( key ) {
+		if( !variables.keyExists("locked") ) return;
+		if( isArray( variables.locked ) && arrayFindNoCase( variables.locked, arguments.key ) )
+			throw( type="CBWIREException", message="Locked properties cannot be updated." );
+		else if ( isSimpleValue( variables.locked ) && arguments.key == variables.locked )
+			throw( type="CBWIREException", message="Locked properties cannot be updated." );
+
+	}
+
+    /**
      * Apply calls to the component
-     * 
+     *
      * @calls array | An array of calls to apply to the component.
-     * 
+     *
      * @return void
      */
     function _applyCalls( calls ) {
@@ -828,7 +846,7 @@ component output="true" {
     /**
      * Returns the validation manager if it's available.
      * Otherwise throws error.
-     * 
+     *
      * @return ValidationManager
      */
     function _getValidationManager(){
@@ -841,7 +859,7 @@ component output="true" {
 
     /**
      * Returns a struct of cbvalidation constraints.
-     * 
+     *
      * @return struct
      */
     function _getConstraints(){
@@ -855,7 +873,7 @@ component output="true" {
      * Parses the dispatch parameters into an array.
      *
      * @params struct | The parameters to parse.
-     * 
+     *
      * @return array
      */
     function _parseDispatchParams( params ) {
@@ -867,7 +885,7 @@ component output="true" {
      * Returns the normalized view path.
      *
      * @viewPath string | The dot notation path to the view template to be rendered, without the .cfm extension.
-     * 
+     *
      * @return string
      */
     function _getNormalizedViewPath( viewPath ) {
@@ -894,8 +912,8 @@ component output="true" {
     }
 
     /**
-     * Handles a dispatched event 
-     * 
+     * Handles a dispatched event
+     *
      * @return void
      */
     function __dispatch( event, params ) {
@@ -918,7 +936,7 @@ component output="true" {
             event="upload:generatedSignedUrl",
             params=[
                 "name"=arguments.prop,
-                "url"=local.uploadURL 
+                "url"=local.uploadURL
             ]
         );
     }
@@ -929,8 +947,8 @@ component output="true" {
      * @prop string | The property for the file input.
      * @params struct | The parameters to pass to the upload method.
      * @self boolean | Whether to dispatch to self.
-     * 
-     * @return void 
+     *
+     * @return void
      */
     function _finishUpload( prop, files, self ) {
         // Dispatch the upload URL
@@ -944,24 +962,24 @@ component output="true" {
     }
 
     /**
-     * Fires when missing methods are called. 
+     * Fires when missing methods are called.
      * Handles computed properties.
-     * 
+     *
      * @missingMethodName string | The name of the missing method.
      * @missingMethodArguments struct | The arguments passed to the missing method.
      *
      * @return any
      */
     function onMissingMethod( missingMethodName, missingMethodArguments ){
-        /* 
-            Check the component's meta data for functions 
+        /*
+            Check the component's meta data for functions
             labeled as computed.
         */
         var meta = variables._metaData;
-        /* 
+        /*
             Handle generated getters and setters for data properties.
             You see we are also preparing the getters and setters in the init method.
-            This is provide access to the dynamic methods both from outside 
+            This is provide access to the dynamic methods both from outside
             the component as well as from within the component.
         */
         if ( arguments.missingMethodName.reFindNoCase( "^get[A-Z].*" ) ) {
@@ -980,7 +998,7 @@ component output="true" {
             }
         }
 
-        /* 
+        /*
             Throw an exception if the missing method is not a computed property.
         */
         throw( type="CBWIREException", message="The method '#arguments.missingMethodName#' does not exist." );
@@ -1001,7 +1019,7 @@ component output="true" {
      * Encodes a given string for safe usage within an HTML attribute.
      *
      * @value string | The string to be encoded.
-     * 
+     *
      * @return String The encoded string suitable for HTML attribute inclusion.
      */
     function _encodeAttribute( value ) {
@@ -1015,15 +1033,15 @@ component output="true" {
      * @html string | The original HTML content to be processed.
      * @snapshotEncoded string | The encoded snapshot data for Livewire's consumption.
      * @id string | The component's unique identifier.
-     * 
+     *
      * @return String The HTML content with Livewire attributes properly inserted.
      */
     function _insertInitialLivewireAttributes( html, snapshotEncoded, id ) {
-        // Trim our html 
+        // Trim our html
         arguments.html = arguments.html.trim();
         // Define the wire attributes to append
         local.wireAttributes = 'wire:snapshot="' & arguments.snapshotEncoded & '" wire:effects="#_generateWireEffectsAttribute()#" wire:id="#variables._id#"';
-        // Determine our outer element 
+        // Determine our outer element
         local.outerElement = _getOuterElement( arguments.html );
         // Find the position of the opening tag
         local.openingTagStart = findNoCase("<" & local.outerElement, arguments.html);
@@ -1034,15 +1052,15 @@ component output="true" {
             local.newOpeningTag = replace(local.openingTag, "<" & local.outerElement, "<" & local.outerElement & " " & local.wireAttributes, "one");
             arguments.html = replace(arguments.html, local.openingTag, local.newOpeningTag, "one");
         }
-        
+
         return arguments.html;
     }
 
     /**
      * Inserts subsequent Livewire-specific attributes into the given HTML content.
-     * 
+     *
      * @html string | The original HTML content to be processed.
-     * 
+     *
      * @return String The HTML content with Livewire attributes properly inserted.
      */
     function _insertSubsequentLivewireAttributes( html ) {
@@ -1058,9 +1076,9 @@ component output="true" {
 
     /**
      * Provides on subsequent mounting for lazy loaded components.
-     * 
+     *
      * @snapshot string | The base64 encoded snapshot.
-     * 
+     *
      * @return void
      */
     function _lazyMount( snapshot ) {
@@ -1074,21 +1092,21 @@ component output="true" {
             return acc;
         }, [:] );
         // Call our onMount method with the params
-        onMount( 
+        onMount(
             event=variables._event,
             rc=variables._event.getCollection(),
             prc=variables._event.getPrivateCollection(),
             params=local.mountParams
         );
     }
-    
+
     /**
      * Renders the content of a view template file.
      * This method is used internally by the view method to render the content of a view template.
-     * 
+     *
      * @normalizedPath string | The normalized path to the view template file.
      * @params struct | The parameters to pass to the view template.
-     * 
+     *
      * @return The rendered content of the view template.
      */
     function _renderViewContent( normalizedPath, params = {} ){
@@ -1113,7 +1131,7 @@ component output="true" {
 
     /**
      * Parses the return values from the RendererEncapsulator.
-     * 
+     *
      * @return void
      */
     function _parseTemplateReturnValues( returnValues ) {
@@ -1159,7 +1177,7 @@ component output="true" {
 
         // Trim and remove any extra spaces between tags for accurate matching
         local.cleanHtml = trim(arguments.trimmedHtml).replaceAll("\s+>", ">");
-        
+
         // Regex to find all tags
         local.tags = reMatch("<\/?[a-z]+[^>]*>", local.cleanHtml);
 
@@ -1171,7 +1189,7 @@ component output="true" {
         // Check for single outer element by comparing the first and last tag
         local.firstTag = tags.first().replaceAll("<\/?([a-z]+)[^>]*>", "$1");
         local.lastTag = tags.last().replaceAll("<\/?([a-z]+)[^>]*>", "$1");
-        
+
         // Check if the first and last tags match and are properly nested
         if ( local.firstTag != local.lastTag ) {
             throw("CBWIRETemplateException", "Template does not have matching outer tags.");
@@ -1204,7 +1222,7 @@ component output="true" {
      * for lazy loading.
      *
      * @params struct | The parameters to pass to the snapshot.
-     * 
+     *
      * @return string
      */
     function _generateXIntersectLazyLoadSnapshot( params = {} ) {
@@ -1237,9 +1255,9 @@ component output="true" {
 
         // Serialize the snapshot to JSON and then encode it for HTML attribute inclusion
         local.lazyLoadSnapshot = serializeJson( local.snapshot );
-    
+
         // Generate the base64 encoded version of the serialized snapshot for use in x-intersect
-        local.base64EncodedSnapshot = toBase64( local.lazyLoadSnapshot );   
+        local.base64EncodedSnapshot = toBase64( local.lazyLoadSnapshot );
 
         // Get our placeholder html
         local.html = placeholder();
@@ -1262,10 +1280,10 @@ component output="true" {
     /**
      * Get the HTTP response for the component
      * for subsequent requests.
-     * 
+     *
      * @componentPayload struct | The payload to hydrate the component with.
      * @httpRequestState struct | The state of the entire HTTP request being returned for all components.
-     * 
+     *
      * @return struct
      */
     function _getHTTPResponse( componentPayload, httpRequestState ){
@@ -1281,11 +1299,11 @@ component output="true" {
         } catch ( any e ) {}
         /*
             Return the html response first. It's important that we do
-            this before calling _getSnapshot() because otherwise any 
+            this before calling _getSnapshot() because otherwise any
             child objects will not have been tracked yet.
         */
         local.html = _render();
-        // Get snapshot 
+        // Get snapshot
         local.snapshot = _getSnapshot();
         // Check snapshot for FileUploads, serialize them if found
         local.snapshot.data.each( function( key, value ) {
@@ -1320,7 +1338,7 @@ component output="true" {
             local.response.effects[ "redirect" ] = variables._redirect;
             local.response.effects[ "redirectUsingNavigate" ] = variables._redirectUsingNavigate;
         }
-        // Add any cbwire:scripts 
+        // Add any cbwire:scripts
         if ( variables._scripts.count() ) {
             local.response.effects[ "scripts" ] = variables._scripts;
         }
@@ -1334,7 +1352,7 @@ component output="true" {
 
     /**
      * Get the snapshot of the component
-     * 
+     *
      * @return struct
      */
     function _getSnapshot() {
@@ -1347,10 +1365,10 @@ component output="true" {
 
     /**
      * Generates a computed property that caches the result of the computed method.
-     * 
+     *
      * @name string | The name of the computed property.
      * @method string | The method to compute the property.
-     * 
+     *
      * @return void
      */
     function _generateComputedProperty( name, method ) {
@@ -1373,7 +1391,7 @@ component output="true" {
 
     /**
      * Prepare our data properties
-     * 
+     *
      * @return void
      */
     function _prepareDataProperties() {
@@ -1396,7 +1414,7 @@ component output="true" {
         */
         variables._initialDataProperties = duplicate( _getDataProperties() );
     }
-     
+
     /**
      * This method will iterate over the component's meta data
      * and prepare any functions labeled as computed for caching.
@@ -1404,7 +1422,7 @@ component output="true" {
      * @return void
      */
     function _prepareComputedProperties() {
-        /* 
+        /*
             Filter the component's meta data for functions labeled as computed.
             For each computed function, generate a computed property
             that caches the result of the computed function.
@@ -1414,7 +1432,7 @@ component output="true" {
         } ).each( function( func ) {
             _generateComputedProperty( func.name, this[func.name] );
         } );
-        
+
         /*
             Look for additional computed properties defined in the 'computed'
             variable scope and generate computed properties for each.
@@ -1428,20 +1446,20 @@ component output="true" {
 
     /**
      * Prepares generated getters and setters for data properties.
-     * We have to generate these getters and setters when the component 
-     * initializes AND also check in onMissingMethod to handle the 
+     * We have to generate these getters and setters when the component
+     * initializes AND also check in onMissingMethod to handle the
      * dynamic methods being called either outside or from within the component.
-     * 
+     *
      * @return void
      */
     function _prepareGeneratedGettersAndSetters() {
-        /* 
+        /*
             Determine our data property names by inspecting
             both the data struct and the components property tags.
         */
         var dataPropertyNames = variables._dataPropertyNames;
 
-        /* 
+        /*
             Loop over our data property names and generate
             getters and setters for each property.
         */
@@ -1461,23 +1479,23 @@ component output="true" {
 
     /**
      * Prepares the component for isolation.
-     * 
+     *
      * @return void
      */
     function _prepareIsolation() {
         // If the component has an isolate method, call it
-        variables._isolate = variables.keyExists( "isolate" ) && isBoolean( variables.isolate ) && variables.isolate ? 
+        variables._isolate = variables.keyExists( "isolate" ) && isBoolean( variables.isolate ) && variables.isolate ?
             true : false;
     }
 
     /**
      * Prepares the component for lazy loading.
-     * 
+     *
      * @return void
      */
     function _prepareLazyLoading() {
         // If the component has a lazyLoad method, call it
-        variables._lazyLoad = variables.keyExists( "lazyLoad" ) && isBoolean( variables.lazyLoad ) && variables.lazyLoad ? 
+        variables._lazyLoad = variables.keyExists( "lazyLoad" ) && isBoolean( variables.lazyLoad ) && variables.lazyLoad ?
             true : false;
 
         if ( variables._lazyLoad ) {
@@ -1487,11 +1505,11 @@ component output="true" {
 
     /**
      * Prepares the component for listening to events.
-     * 
+     *
      * @return void
      */
     function _prepareListeners() {
-        /* 
+        /*
             listers = {
                 'eventName': 'methodName'
             }
@@ -1523,7 +1541,7 @@ component output="true" {
 
     /**
      * Returns the module name.
-     * 
+     *
      * @return string
      */
     function _getModuleName() {
@@ -1532,7 +1550,7 @@ component output="true" {
 
     /**
      * Returns the data properties and their values.
-     * 
+     *
      * @return struct
      */
     function _getDataProperties(){
@@ -1548,7 +1566,7 @@ component output="true" {
 
     /**
      * Returns the component's memo data.
-     * 
+     *
      * @return struct
      */
     function _getMemo(){
@@ -1570,9 +1588,9 @@ component output="true" {
 
     /**
      * Returns the component's name.
-     * 
+     *
      * @return string
-     
+
      */
     function _getComponentName(){
         if ( variables._metaData.name contains "cbwire.models.tmp." ) {
@@ -1585,9 +1603,9 @@ component output="true" {
     /**
      * Take an incoming rendering and determine the outer component tag.
      * <div>...</div> would return 'div'
-     * 
+     *
      * @rendering string | The rendering to parse.
-     * 
+     *
      * @return string
      */
     function _getComponentTag( rendering ){
@@ -1601,7 +1619,7 @@ component output="true" {
 
     /**
      * Returns a generated key for the component.
-     * 
+     *
      * @return string
      */
     function _generateWireKey(){
@@ -1610,7 +1628,7 @@ component output="true" {
 
     /**
      * Returns the component's script tags.
-     * 
+     *
      * @return struct
      */
     function _getScripts(){
@@ -1619,7 +1637,7 @@ component output="true" {
 
     /**
      * Returns the component's meta data.
-     * 
+     *
      * @return struct
      */
     function _getMetaData(){
@@ -1628,7 +1646,7 @@ component output="true" {
 
     /**
      * Returns the validation result.
-     * 
+     *
      * @return ValidationResult
      */
     function _getValidationResult(){
@@ -1637,7 +1655,7 @@ component output="true" {
 
     /**
      * Returns the wire:effects attribute contents.
-     * 
+     *
      * @return string
      */
     function _generateWireEffectsAttribute() {
@@ -1679,7 +1697,7 @@ component output="true" {
     /**
      * Returns the first outer element from the provided html.
      * "<div x-data=""></div>" returns "div";
-     * 
+     *
      * @return string
      */
     function _getOuterElement( html ) {
@@ -1690,7 +1708,7 @@ component output="true" {
 
     /**
      * Returns true if the path contains a module.
-     * 
+     *
      * @return boolean
      */
     function isModulePath() {
@@ -1699,7 +1717,7 @@ component output="true" {
 
     /**
      * Returns true if the cbvalidation module is installed.
-     * 
+     *
      * @return boolean
      */
     function _isCBValidationInstalled() {
@@ -1714,11 +1732,11 @@ component output="true" {
     /**
      * Returns true if trimStringValues is enabled, either globally
      * or for the component.
-     * 
+     *
      * @return boolean
      */
     function shouldTrimStringValues() {
-        return 
+        return
             ( _globalSettings.keyExists( "trimStringValues" ) && _globalSettings.trimStringValues == true ) ||
             ( variables.keyExists( "trimStringValues" ) && variables.trimStringValues == true );
     }

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -191,7 +191,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 var result = CBWIREController.wire( "test.should_support_computed_properties" );
                 expect( reFindNoCase( "UUID: [A-Za-z0-9-]+", result ) ).toBeGT( 0 );
             } );
-            
+
             it( "should cache computed properties", function() {
                 var result = CBWIREController.wire( "test.should_cache_computed_properties" );
                 var firstUUID = reFindNoCase( "UUID: ([A-Za-z0-9-]+)", result, 1, true ).match[ 2 ];
@@ -685,7 +685,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 expect( response.components[1].effects.html ).toInclude( "CBWIRE Slays!" );
             } );
 
-            it( "should run action we pass it with parameters", function() {  
+            it( "should run action we pass it with parameters", function() {
                 var payload = incomingRequest(
                     memo = {
                         "name": "TestComponent",
@@ -704,7 +704,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     ],
                     updates = {}
                 );
-                
+
                 var response = cbwireController.handleRequest( payload, event );
                 expect( response.components[1].effects.html ).toInclude( "Title: Hello world from CBWIRE!" );
             } );
@@ -1128,6 +1128,84 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 var response = cbwireController.handleRequest( payload, event );
                 expect( response.components[1].effects.html ).toInclude( "CBWIRE Slaps!" );
             } );
+
+            it( "should throw a CBWIREException when trying to update a locked property (array)", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.should_throw_exception_on_locked_data_property_array",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {},
+                    calls = [],
+                    updates = { "lockedPropertyKey" : "Changed Value" }
+                );
+				expect( function() {
+					cbwireController.handleRequest( payload, event );
+				} ).toThrow( message="The property lockedPropertyKey is locked and cannot be updated."  );
+            } );
+
+            it( "should throw a CBWIREException when trying to update a locked property (string)", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.should_throw_exception_on_locked_data_property_string",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {},
+                    calls = [],
+                    updates = { "lockedPropertyKey" : "Changed Value" }
+                );
+				expect( function() {
+					cbwireController.handleRequest( payload, event );
+				} ).toThrow( message="The property lockedPropertyKey is locked and cannot be updated."  );
+            } );
+
+            it( "should not throw an error when empty array is used for locked property ", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.should_not_throw_exception_on_locked_data_property_empty_array",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {},
+                    calls = [],
+                    updates = { "lockedPropertyKey" : "Changed Value" }
+                );
+                var response = cbwireController.handleRequest( payload, event );
+                expect( response.components[1].effects.html ).toInclude( "Locked Property Value: Changed Value" );
+            } );
+
+            it( "should not throw an error when empty string is used for locked property ", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.should_not_throw_exception_on_locked_data_property_empty_string",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {},
+                    calls = [],
+                    updates = { "lockedPropertyKey" : "Changed Value" }
+                );
+                var response = cbwireController.handleRequest( payload, event );
+                expect( response.components[1].effects.html ).toInclude( "Locked Property Value: Changed Value" );
+            } );
+
+            it( "should not throw an error when data type other than array or string is used for locked property ", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.should_not_throw_exception_on_locked_data_property_other",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {},
+                    calls = [],
+                    updates = { "lockedPropertyKey" : "Changed Value" }
+                );
+                var response = cbwireController.handleRequest( payload, event );
+                expect( response.components[1].effects.html ).toInclude( "Locked Property Value: Changed Value" );
+            } );
+
         } );
 
         describe("File Uploads", function() {
@@ -1360,7 +1438,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			it( "throws error if it's unable to find a module component", function() {
 				expect( function() {
 					var result = cbwireController.wire( "missing@someModule" );
-				} ).toThrow( type="ModuleNotFound" );  
+				} ).toThrow( type="ModuleNotFound" );
 			} );
 
 			it( "can render component from nested module using default wires location", function() {
@@ -1383,41 +1461,41 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     preprocessor = getInstance("CBWIREPreprocessor@cbwire");
                     prepareMock( preprocessor );
                 });
-    
+
                 it("should parse and replace single cbwire tag with no arguments", function() {
                     var input = "<cbwire:testComponent/>";
                     var expected = "##wire( name=""testComponent"", params={ }, lazy=false )##";
                     var result = preprocessor.handle(input);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should parse and replace cbwire tag with multiple arguments", function() {
                     var input = "<cbwire:testComponent :param1='value1' param2='value2'/>";
                     var expected = "##wire( name=""testComponent"", params={ param1=value1, param2='value2' }, lazy=false )##";
                     var result = preprocessor.handle(input);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should correctly handle arguments with expressions", function() {
                     var input = "<cbwire:testComponent :expr='someExpression'/>";
                     var expected = "##wire( name=""testComponent"", params={ expr=someExpression }, lazy=false )##";
                     var result = preprocessor.handle(input);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should maintain order and syntax of multiple attributes", function() {
                     var input = "<cbwire:testComponent attr1='foo' :expr='bar' attr2='baz'/>";
                     var expected = "##wire( name=""testComponent"", params={ attr1='foo', expr=bar, attr2='baz' }, lazy=false )##";
                     var result = preprocessor.handle(input);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should replace multiple cbwire tags in a single content string", function() {
                     var input = "Here is a test <cbwire:firstComponent attr='value'/> and another <cbwire:secondComponent :expr='expression'/>";
                     var expected = "Here is a test ##wire( name=""firstComponent"", params={ attr='value' }, lazy=false )## and another ##wire( name=""secondComponent"", params={ expr=expression }, lazy=false )##";
                     var result = preprocessor.handle(input);
                     expect(result).toBe(expected);
-                }); 
+                });
 
                 it("should throw an exception for unparseable tags", function() {
                     var input = "<cbwire:testComponent :broken='noEndQuote>";
@@ -1434,56 +1512,56 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     // Create an instance of the component that handles teleport preprocessing
                     preprocessor = getInstance( "TeleportPreprocessor@cbwire" );
                 });
-    
+
                 it("should replace @teleport with the correct template tag", function() {
                     var content = "@teleport(selector) content @endteleport";
                     var expected = '<template x-teleport="selector"> content </template>';
                     var result = preprocessor.handle(content);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should handle single quotes around the selector", function() {
                     var content = "@teleport('selector') content @endteleport";
                     var expected = '<template x-teleport="selector"> content </template>';
                     var result = preprocessor.handle(content);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should handle double quotes around the selector", function() {
                     var content = '@teleport("selector") content @endteleport';
                     var expected = '<template x-teleport="selector"> content </template>';
                     var result = preprocessor.handle(content);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should handle no quotes around the selector", function() {
                     var content = "@teleport(selector) content @endteleport";
                     var expected = '<template x-teleport="selector"> content </template>';
                     var result = preprocessor.handle(content);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should handle spaces within the parentheses", function() {
                     var content = "@teleport(   selector   ) content @endteleport";
                     var expected = '<template x-teleport="selector"> content </template>';
                     var result = preprocessor.handle(content);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should handle multiple teleport directives in the same content", function() {
                     var content = "@teleport(selector1) content1 @endteleport @teleport(selector2) content2 @endteleport";
                     var expected = '<template x-teleport="selector1"> content1 </template> <template x-teleport="selector2"> content2 </template>';
                     var result = preprocessor.handle(content);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should handle nested teleport directives", function() {
                     var content = "@teleport(outer) @teleport(inner) content @endteleport @endteleport";
                     var expected = '<template x-teleport="outer"> <template x-teleport="inner"> content </template> </template>';
                     var result = preprocessor.handle(content);
                     expect(result).toBe(expected);
                 });
-    
+
                 it("should not alter content without teleport directives", function() {
                     var content = "Normal content without directives";
                     var result = preprocessor.handle(content);
@@ -1497,9 +1575,9 @@ component extends="coldbox.system.testing.BaseTestCase" {
     /**
      * Helper test method for creating incoming request payloads
      *
-     * @data 
+     * @data
      * @calls
-     * 
+     *
      * @return struct
      */
     private function incomingRequest(
@@ -1539,7 +1617,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
     /**
      * Take a rendered HTML component and breaks out its snapshot,
      * effects, etc for analysis during tests.
-     * 
+     *
      * @return struct
      */
     private function parseRendering( html, index = 1 ) {
@@ -1547,16 +1625,16 @@ component extends="coldbox.system.testing.BaseTestCase" {
         // Determine outer element
         local.outerElementMatches = reMatchNoCase( "<([a-z]+)\s*", html );
         local.result[ "outerElement" ] = reFindNoCase( "<([a-z]+)\s*", html, 1, true ).match[ 2 ];
-        // Parse snapshot 
+        // Parse snapshot
         local.result[ "snapshot" ] = parseSnapshot( html, index );
-        // Parse effects 
+        // Parse effects
         local.result[ "effects" ] = parseEffects( html, index );
         return local.result;
     }
 
     /**
      * Parse the snapshot from a rendered HTML component
-     * 
+     *
      * @return struct
      */
     private function parseSnapshot( html, index = 1 ) {
@@ -1569,7 +1647,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
     /**
      * Parse the effects from a rendered HTML component
-     * 
+     *
      * @return struct
      */
     private function parseEffects( html, index = 1 ) {

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -1145,6 +1145,22 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} ).toThrow( message="The property lockedPropertyKey is locked and cannot be updated."  );
             } );
 
+            it( "should throw a CBWIREException when trying to update a locked property (list)", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.should_throw_exception_on_locked_data_property_list",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {},
+                    calls = [],
+                    updates = { "lockedPropertyKey" : "Changed Value" }
+                );
+				expect( function() {
+					cbwireController.handleRequest( payload, event );
+				} ).toThrow( message="The property lockedPropertyKey is locked and cannot be updated."  );
+            } );
+
             it( "should throw a CBWIREException when trying to update a locked property (string)", function() {
                 var payload = incomingRequest(
                     memo = {

--- a/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_empty_array.cfm
+++ b/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_empty_array.cfm
@@ -1,0 +1,18 @@
+<cfoutput>
+    <div>
+        <h1>Should Throw Exception on Locked Property</h1>
+		<p>When a locked property is an empty array it should ignore and display the value below.</p>
+		<p>Locked Property Value: #lockedPropertyKey#</p>
+    </div>
+</cfoutput>
+
+<cfscript>
+    // @startWire
+    data = {
+        "lockedPropertyKey": "I AM NOT LOCKED!"
+    };
+
+	locked = [];
+
+    // @endWire
+</cfscript>

--- a/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_empty_array.cfm
+++ b/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_empty_array.cfm
@@ -1,7 +1,7 @@
 <cfoutput>
     <div>
-        <h1>Should Throw Exception on Locked Property</h1>
-		<p>When a locked property is an empty array it should ignore and display the value below.</p>
+        <h1>Should Not Throw Exception</h1>
+		<p>When a locked property is an empty array the wire should ignore continue.</p>
 		<p>Locked Property Value: #lockedPropertyKey#</p>
     </div>
 </cfoutput>

--- a/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_empty_string.cfm
+++ b/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_empty_string.cfm
@@ -1,0 +1,18 @@
+<cfoutput>
+    <div>
+        <h1>Should Throw Exception on Locked Property</h1>
+		<p>When a locked property is an empty string it should ignore and display the value below.</p>
+		<p>Locked Property Value: #lockedPropertyKey#</p>
+    </div>
+</cfoutput>
+
+<cfscript>
+    // @startWire
+    data = {
+        "lockedPropertyKey": "I AM NOT LOCKED!"
+    };
+
+	locked = "";
+
+    // @endWire
+</cfscript>

--- a/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_empty_string.cfm
+++ b/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_empty_string.cfm
@@ -1,7 +1,7 @@
 <cfoutput>
     <div>
-        <h1>Should Throw Exception on Locked Property</h1>
-		<p>When a locked property is an empty string it should ignore and display the value below.</p>
+        <h1>Should Not Throw Exception</h1>
+		<p>When a locked property is an empty string the wire should ignore continue.</p>
 		<p>Locked Property Value: #lockedPropertyKey#</p>
     </div>
 </cfoutput>

--- a/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_other.cfm
+++ b/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_other.cfm
@@ -1,7 +1,7 @@
 <cfoutput>
     <div>
-        <h1>Should Throw Exception on Locked Property</h1>
-		<p>When a locked property other than an array or string is used it should ignore and display the value below.</p>
+        <h1>Should Not Throw Exception</h1>
+		<p>When a locked property is a data type other than an array, string/list the wire should ignore continue.</p>
 		<p>Locked Property Value: #lockedPropertyKey#</p>
     </div>
 </cfoutput>
@@ -12,7 +12,7 @@
         "lockedPropertyKey": "I AM NOT LOCKED!"
     };
 
-	locked = { "someKey" : "someValue" };
+	locked = { "lockedPropertyKey" : "someValue" };
 
     // @endWire
 </cfscript>

--- a/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_other.cfm
+++ b/test-harness/wires/test/should_not_throw_exception_on_locked_data_property_other.cfm
@@ -1,0 +1,18 @@
+<cfoutput>
+    <div>
+        <h1>Should Throw Exception on Locked Property</h1>
+		<p>When a locked property other than an array or string is used it should ignore and display the value below.</p>
+		<p>Locked Property Value: #lockedPropertyKey#</p>
+    </div>
+</cfoutput>
+
+<cfscript>
+    // @startWire
+    data = {
+        "lockedPropertyKey": "I AM NOT LOCKED!"
+    };
+
+	locked = { "someKey" : "someValue" };
+
+    // @endWire
+</cfscript>

--- a/test-harness/wires/test/should_throw_exception_on_locked_data_property_array.cfm
+++ b/test-harness/wires/test/should_throw_exception_on_locked_data_property_array.cfm
@@ -1,7 +1,7 @@
 <cfoutput>
     <div>
         <h1>Should Throw Exception on Locked Property</h1>
-		<p>When a property is locked with an array, it should throw an exception when trying to set it.</p>
+		<p>When a property is locked with an array, it should throw an exception when trying to set any of the keys in the array.</p>
     </div>
 </cfoutput>
 

--- a/test-harness/wires/test/should_throw_exception_on_locked_data_property_array.cfm
+++ b/test-harness/wires/test/should_throw_exception_on_locked_data_property_array.cfm
@@ -1,0 +1,17 @@
+<cfoutput>
+    <div>
+        <h1>Should Throw Exception on Locked Property</h1>
+		<p>When a property is locked with an array, it should throw an exception when trying to set it.</p>
+    </div>
+</cfoutput>
+
+<cfscript>
+    // @startWire
+    data = {
+        "lockedPropertyKey": "I AM LOCKED!"
+    };
+
+	locked = ["lockedPropertyKey"];
+
+    // @endWire
+</cfscript>

--- a/test-harness/wires/test/should_throw_exception_on_locked_data_property_list.cfm
+++ b/test-harness/wires/test/should_throw_exception_on_locked_data_property_list.cfm
@@ -1,0 +1,19 @@
+<cfoutput>
+    <div>
+        <h1>Should Throw Exception on Locked Property</h1>
+		<p>When a property is locked with an list, it should throw an exception when trying to set any of the keys in the list.</p>
+    </div>
+</cfoutput>
+
+<cfscript>
+    // @startWire
+    data = {
+        "lockedPropertyKey": "I AM LOCKED!",
+        "lockedPropertyKeyTwo": "I AM ALSO LOCKED!",
+        "lockedPropertyKeyThree": "I AM LOCKED AS WELL!"
+    };
+
+	locked = "lockedPropertyKeyThree,lockedPropertyKey";
+
+    // @endWire
+</cfscript>

--- a/test-harness/wires/test/should_throw_exception_on_locked_data_property_string.cfm
+++ b/test-harness/wires/test/should_throw_exception_on_locked_data_property_string.cfm
@@ -1,0 +1,17 @@
+<cfoutput>
+    <div>
+        <h1>Should Throw Exception on Locked Property</h1>
+		<p>When a property is locked with an array, it should throw an exception when trying to set it.</p>
+    </div>
+</cfoutput>
+
+<cfscript>
+    // @startWire
+    data = {
+        "lockedPropertyKey": "I AM LOCKED!"
+    };
+
+	locked = "lockedPropertyKey";
+
+    // @endWire
+</cfscript>

--- a/test-harness/wires/test/should_throw_exception_on_locked_data_property_string.cfm
+++ b/test-harness/wires/test/should_throw_exception_on_locked_data_property_string.cfm
@@ -1,7 +1,7 @@
 <cfoutput>
     <div>
         <h1>Should Throw Exception on Locked Property</h1>
-		<p>When a property is locked with an array, it should throw an exception when trying to set it.</p>
+		<p>When a property is locked with an string (single value), it should throw an exception when trying to set the provided key.</p>
     </div>
 </cfoutput>
 


### PR DESCRIPTION
Adds ability to include `locked = ["dataKeyName"]` to a wire that will prevent updating from incoming requests.

[ Addresses issue #77 ](https://github.com/coldbox-modules/cbwire/issues/77)

- `locked` can be set to an array of keys `locked = ["dataKeyName","dataKeyTwoName"]`, a comma seperated list  `locked = "dataKeyName,dataKeyNameTwo,dataKeyNameThree"`, or a string with a single key name `locked = "dataKeyName"` 
- Added `_validateLockedProperty()` function to models/Component.cfc
- `_validateLockedProperty()` is called in the `_applyUpdates()` while looping over incoming updates and throws exception if updating a locked data property
-  Added six tests
    - should throw a CBWIREException when trying to update a locked property (array)
	- should throw a CBWIREException when trying to update a locked property (list)
    - should throw a CBWIREException when trying to update a locked property (string)
    - should not throw an error when empty array is used for locked property
    - should not throw an error when empty string is used for locked property
    - should not throw an error when data type other than array or string is used for locked property

Similar to livewire, the locked data properties are only prevented from being changed on incoming updates from client.