### PR TITLE
Separate the path where temporary files uploaded by the user are stor…

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -15,7 +15,7 @@ component {
     function configure(){
         settings = {
             /**
-             * Set to true to automatically include CSS and JS 
+             * Set to true to automatically include CSS and JS
              * assets for CBWIRE. This makes it where you do not
              * need to add wireStyles() and wireScripts() to your layout.
              */
@@ -24,6 +24,10 @@ component {
              * Capture our module root for use throughout CBWIRE.
              */
             "moduleRootPath": getCanonicalPath( getCurrentTemplatePath().replaceNoCase( "/ModuleConfig.cfc", "", "one" ) ),
+            /**
+             * The default storage path for all cbwire components.
+             */
+            "storagePath": getCanonicalPath( getCurrentTemplatePath().replaceNoCase( "/ModuleConfig.cfc", "", "one" ) & "/models/tmp" ),
             /**
              * Set to true to throw a 'WireSetterNotFound' exception if
              * the incoming cbwire request tries to update a property
@@ -43,7 +47,7 @@ component {
              * Enables or disables the progress bar when using wire:navigate
              */
             "showProgressBar": true,
-            /** 
+            /**
              * The color of the progress bar when using wire:navigate
              */
             "progressBarColor": "##2299dd"

--- a/models/CBWIREController.cfc
+++ b/models/CBWIREController.cfc
@@ -11,7 +11,7 @@ component singleton {
 
     // Inject module settings
     property name="moduleSettings" inject="coldbox:modulesettings:cbwire";
-    
+
     // Inject module service
     property name="moduleService" inject="coldbox:moduleService";
 
@@ -43,8 +43,8 @@ component singleton {
                 ._withKey( arguments.key );
 
         // If the component is lazy loaded, we need to generate an x-intersect snapshot of the component
-        return arguments.lazy ? 
-            local.instance._generateXIntersectLazyLoadSnapshot( params=arguments.params ) : 
+        return arguments.lazy ?
+            local.instance._generateXIntersectLazyLoadSnapshot( params=arguments.params ) :
             local.instance._render();
     }
 
@@ -53,7 +53,7 @@ component singleton {
      *
      * @incomingRequest The JSON struct payload of the incoming request.
      * @event The event object.
-     * 
+     *
      * @return A struct representing the response with updated component details or an error message.
      */
     function handleRequest( incomingRequest, event ) {
@@ -121,15 +121,15 @@ component singleton {
     /**
      * Uploads all files from the request to the specified destination
      * after verifying the signed URL.
-     * 
+     *
      * @incomingRequest The JSON struct payload of the incoming request.
      * @event The event object.
-     * 
+     *
      * @return A struct representing the response with updated component details or an error message.
      */
     function handleFileUpload( incomingRequest, event ) {
         // Determine our storage path for temporary files
-        local.storagePath = getCanonicalPath( variables.moduleSettings.moduleRootPath & "/models/tmp" );
+        local.storagePath = getCanonicalPath( variables.moduleSettings.storagePath );
 
         // Ensure the storage path exists
         if( !directoryExists( local.storagePath ) ){
@@ -158,10 +158,10 @@ component singleton {
 
     /**
      * Handles the preview of a file by reading the file metadata and sending it back to the client.
-     * 
+     *
      * @incomingRequest The JSON struct payload of the incoming request.
      * @event The event object.
-     * 
+     *
      * @return file contents
      */
     function handleFilePreview( incomingRequest, event ){
@@ -170,10 +170,10 @@ component singleton {
             return event.noRender();
         }
 
-        local.metaPath = getCanonicalPath( variables.moduleSettings.moduleRootPath & "models/tmp/#local.uuid#.json" );
+        local.metaPath = getCanonicalPath( variables.moduleSettings.storagePath & "/#local.uuid#.json" );
 
         local.metaJSON = deserializeJSON( fileRead( local.metaPath ) );
-        local.contents = fileReadBinary( getCanonicalPath( variables.moduleSettings.moduleRootPath & "models/tmp/#local.metaJSON.serverFile#" ) );
+        local.contents = fileReadBinary( getCanonicalPath( variables.moduleSettings.storagePath & "/#local.metaJSON.serverFile#" ) );
         event
             .sendFile(
                 file = local.contents,
@@ -191,18 +191,18 @@ component singleton {
      * @componentName The name of the component to instantiate, possibly including a namespace.
      * @params Optional parameters to pass to the component constructor.
      * @key Optional key to use when retrieving the component from WireBox.
-     * 
+     *
      * @return The instantiated component object.
      * @throws ApplicationException If the component cannot be found or instantiated.
      */
     function createInstance( name ) {
         // Determine if the component name traverses a valid namespace or directory structure
         local.fullComponentPath = arguments.name;
-        
+
         if ( !local.fullComponentPath contains "wires." ) {
             local.fullComponentPath = "wires." & local.fullComponentPath;
         }
-        
+
         if ( find( "@", local.fullComponentPath ) ) {
             // This is a module reference, find in our module
             var params = listToArray( local.fullComponentPath, "@" );
@@ -243,9 +243,9 @@ component singleton {
         }
     }
 
-    /** 
+    /**
     * Returns the path to the modules folder.
-    * 
+    *
     * @module string | The name of the module.
     *
     * @return string
@@ -286,8 +286,8 @@ component singleton {
      * Returns the path to the wires folder within a module path.
      *
      * @module string | The name of the module.
-     * 
-     * @return string 
+     *
+     * @return string
      */
     function getModuleWiresPath( module ) {
         local.moduleRegistry = moduleService.getModuleRegistry();
@@ -296,7 +296,7 @@ component singleton {
 
     /**
      * Returns the ColdBox RequestContext object.
-     * 
+     *
      * @return The ColdBox RequestContext object.
      */
     function getEvent(){
@@ -305,7 +305,7 @@ component singleton {
 
     /**
      * Returns any request assets defined by components during the request.
-     * 
+     *
      * @return struct
      */
     function getRequestAssets() {
@@ -316,7 +316,7 @@ component singleton {
 
     /**
      * Returns the ColdBox ConfigSettings object.
-     * 
+     *
      * @return struct
      */
     function getConfigSettings(){
@@ -325,7 +325,7 @@ component singleton {
 
     /**
      * Returns an array of preprocessor instances.
-     * 
+     *
      * @return An array of preprocessor instances.
      */
     function getPreprocessors(){
@@ -333,7 +333,7 @@ component singleton {
         if( structKeyExists( variables, "preprocessors" ) ){
             return variables.preprocessors;
         }
-        // List of preprocesssors here. Had to hard code instead of using 
+        // List of preprocesssors here. Had to hard code instead of using
         // directoryList because of filesystem differences in various OSes
         local.files = [
             "TemplatePreprocessor.cfc",
@@ -351,18 +351,18 @@ component singleton {
 
     /**
      * Returns CSS styling needed by Livewire.
-     * 
+     *
      * @return string
      */
     function getStyles( cache=true ) {
         if (structKeyExists(variables, "styles") && arguments.cache ) {
             return variables.styles;
         }
-        
+
         savecontent variable="local.html" {
             include "styles.cfm";
         }
-        
+
         variables.styles = local.html;
         return variables.styles;
     }
@@ -372,10 +372,10 @@ component singleton {
      * We don't cache the results like we do with
      * styles because we need to generate a unique
      * CSRF token for each request.
-     * 
+     *
      * @return string
      */
-    function getScripts() {       
+    function getScripts() {
         savecontent variable="local.html" {
             include "scripts.cfm";
         }
@@ -384,7 +384,7 @@ component singleton {
 
     /**
      * Returns HTML to persist the state of anything inside the call.
-     * 
+     *
      * @return string
      */
     function persist( name ) {
@@ -393,7 +393,7 @@ component singleton {
 
     /**
      * Ends the persistence of the state of anything inside the call.
-     * 
+     *
      * @return string
      */
     function endPersist() {
@@ -402,10 +402,10 @@ component singleton {
 
     /**
      * Generates a secure signature for the upload URL.
-     * 
+     *
      * @baseURL string | The base URL for the upload request.
      * @expires string | The expiration time for the request.
-     * 
+     *
      * @return string
      */
     function generateSignature(baseUrl, expires) {
@@ -419,7 +419,7 @@ component singleton {
 
     /**
      * Generates a CSRF token for the current request.
-     * 
+     *
      * @return string
      */
     function generateCSRFToken() {
@@ -429,7 +429,7 @@ component singleton {
 
     /**
      * Returns the base URL for incoming requests.
-     * 
+     *
      * @return string
      */
     function getBaseURL() {
@@ -457,7 +457,7 @@ component singleton {
 
     /**
      * Verifies signed upload URL.
-     * 
+     *
      * @return boolean
      */
     function verifySignedUploadURL( expires, signature ) {
@@ -523,11 +523,11 @@ component singleton {
 
     /**
      * Returns the URI endpoint for updating CBWIRE components.
-     * 
+     *
      * @return string
      */
     function getUpdateEndpoint() {
-        var settings = variables.moduleSettings;        
+        var settings = variables.moduleSettings;
         return settings.keyExists( "updateEndpoint") && settings.updateEndpoint.len() ? settings.updateEndpoint : "/cbwire/update";
     }
 }

--- a/models/FileUpload.cfc
+++ b/models/FileUpload.cfc
@@ -1,4 +1,4 @@
-/** 
+/**
  * This is the file entity that is used to represent a file that has been uploaded
  * to the server. It is used to store the file in a temporary location and to
  * provide access to the file's metadata.
@@ -19,8 +19,8 @@ component {
         variables.dataPropertyName = arguments.dataPropertyName; // getParams()[ 1 ]
         // The UUID of the file upload we provided after the upload was complete
         variables.uuid = arguments.uuid; // getParams()[ 2 ][ 1 ]
-        // The temp directory 
-        local.tempDirectory = getCanonicalPath( variables.moduleSettings.moduleRootPath & "models/tmp" );
+        // The temp directory
+        local.tempDirectory = getCanonicalPath( variables.moduleSettings.storagePath );
         // The file upload metadata JSON file path
         variables.metaPath = getCanonicalPath( local.tempDirectory & "/#variables.uuid#.json" );
         // Load the metadata, throw and exception if fails
@@ -38,25 +38,25 @@ component {
 
     /**
      * Returns the base64 representation of the file
-     * 
+     *
      * @return string
      */
     function getBase64(){
         return toBase64( get() );
     }
 
-    /** 
+    /**
      * Returns the base64 src of the file
-     * 
+     *
      * @return string
      */
     function getBase64Src(){
         return "data:#getMimeType()#;base64, #getBase64()#";
     }
 
-    /** 
+    /**
      * Returns the binary for the uploaded file.
-     * 
+     *
      * @return binary
      */
     function get(){
@@ -65,43 +65,43 @@ component {
 
     /**
      * Returns the file's size.
-     * 
+     *
      * @return numeric
      */
     function getSize(){
         return variables.meta.fileSize;
     }
 
-    /** 
+    /**
      * Returns the file's MIME type.
-     * 
+     *
      * @return string
      */
     function getMIMEType(){
         return variables.meta.contentType & "/" & variables.meta.contentSubType;
     }
 
-    /** 
-     * Returns true if the uploaded file is an image. 
-     * 
+    /**
+     * Returns true if the uploaded file is an image.
+     *
      * @return boolean
      */
     function isImage(){
         return variables.meta.contentType == "image";
     }
 
-    /** 
+    /**
      * Returns the file's preview URL.
-     * 
+     *
      * @return string
      */
     function getPreviewURL(){
         return "/cbwire/preview-file/#variables.uuid#";
     }
 
-    /** 
+    /**
      * Deletes the file in temporary storage and the metadata file.
-     * 
+     *
      * @return void
      */
     function destroy(){
@@ -111,9 +111,9 @@ component {
     }
 
 
-    /* 
+    /*
      * Serialize the file upload
-     * 
+     *
      * @return string
      */
     function serializeIt() {


### PR DESCRIPTION
Separate the path where temporary files uploaded by the user are stored in a configuration variable.

We need to save the temporary images uploaded by the files (`<input wire:model="..." ...>`) in a different directory than the configuration directory so that it is shared by all front-end server machines.

This change creates a new configuration variable (`storagePath`) that keeps the original default value, but allows the developer to change that directory to a different one with a simple change:

```patch
$ git diff config/modules/cbwire.cfc
diff --git a/config/modules/cbwire.cfc b/config/modules/cbwire.cfc
index 68ab6238d4..54fb9f0ea0 100644
--- a/config/modules/cbwire.cfc
+++ b/config/modules/cbwire.cfc
@@ -2,7 +2,8 @@ component {
 
   function configure(){
     return {
+      "storagePath": "/other/dir/by/example/tmp",
     }
   }
```

