### PR TITLE
Add function getTemporaryStoragePath to FileUpload.cfc

### DIFF
--- a/models/FileUpload.cfc
+++ b/models/FileUpload.cfc
@@ -99,6 +99,15 @@ component {
         return "/cbwire/preview-file/#variables.uuid#";
     }
 
+    /**
+     * Returns the temporary file path
+     *
+     * @return string
+     */
+    function getTemporaryStoragePath(){
+      return variables.temporaryStoragePath;
+    }
+
     /** 
      * Deletes the file in temporary storage and the metadata file.
      * 


### PR DESCRIPTION
In order to move the tmp file to  another directory, we need the temporary store path.

This patch add a function to return TemporaryStoragePath.

