### PR TITLE
Not remove the files in the temp directory

### DIFF
--- a/models/CBWIREController.cfc
+++ b/models/CBWIREController.cfc
@@ -135,13 +135,6 @@ component singleton {
         if( !directoryExists( local.storagePath ) ){
             directoryCreate( local.storagePath );
         }
-        // Cleanup files in the storage path by checking for files older than 1 days
-        local.files = directoryList( path=local.storagePath, recurse=true, type="file", listInfo="query" );
-        local.files.each( function( _file ) {
-            if( dateDiff( "d", _file.DateLastModified, now() ) > 1 ){
-                fileDelete( _file );
-            }
-        } );
         // Verify the signed URL, throw 403 if invalid
         if( !verifySignedUploadURL( expires=event.getValue( "expires" ), signature=event.getValue( "signature" ) ) ){
             return event.renderData( statusCode=403, statusText="Forbidden", data="Invalid signed URL." );


### PR DESCRIPTION
With the inclusion of the config `storagePath`, the temp path could be not only for cbwire, sharing the directory to other functions.

So now, it dangerous to remove all files in the temp directory.

