### PR TITLE
Dot notation data props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test-harness/testbox/**
 test-harness/tests/results/**
 test-harness/logs/**
 test-harness/modules/**
+views/tmp/**
 
 # log files
 logs/**
@@ -24,3 +25,5 @@ node_modules/**
 livewire/**
 
 models/tmp/**
+
+.DS_Store

--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -528,7 +528,7 @@ component output="true" accessors="true" {
         if ( !variables._event.privateValueExists( "_cbwire_stream" ) ) {
             cfcontent( reset=true );
             variables._event.setPrivateValue( "_cbwire_stream", true );
-            cfheader( statusCode=200, statustext="OK" );
+            cfheader( statusCode=200 );
             cfheader( name="Cache-Control", value="no-cache, private" );
             cfheader( name="Host", value=cgi.http_host );
             cfheader( name="Content-Type", value="text/event-stream" );
@@ -788,24 +788,31 @@ component output="true" accessors="true" {
                 local.regexMatch = reFindNoCase( "(.+)\.([0-9]+)", arguments.key, 1, true );
                 local.propertyName = local.regexMatch.match[ 2 ];
                 local.arrayIndex = local.regexMatch.match[ 3 ];
-                variables.data[ local.propertyName][ local.arrayIndex + 1 ] = isNumeric( arguments.value ) ? val( arguments.value ) : arguments.value;
-                // Track that we updated an array property
+				local.currentArray = structGet( "variables.data." & local.propertyName );
+				local.currentArray[ local.arrayIndex + 1 ] = isNumeric( arguments.value ) ? val( arguments.value ) : arguments.value;
+				updateNestedKey( local.propertyName, local.currentArray );
+				// Track that we updated an array property
                 if ( !arrayFindNoCase( updatedArrayProps, local.propertyName ) ) {
                     updatedArrayProps.append( local.propertyName );
                 }
             } else {
-                local.oldValue = variables.data[ key ];
-                variables.data[ key ] = arguments.value;
-                if ( structKeyExists( this, "onUpdate#key#") ) {
-                    invoke( this, "onUpdate#key#", { value: arguments.value, oldValue: local.oldValue });
+                local.oldValue = structGet( "variables.data." & key );
+                updateNestedKey( key, arguments.value );
+				var onUpdateFunctionName = "onUpdate" & key.replace( ".", "_", "all" );
+				if ( structKeyExists( this, onUpdateFunctionName) ) {
+                    invoke( this, onUpdateFunctionName, { value: arguments.value, oldValue: local.oldValue });
                 }
             }
         } );
 
         local.updatedArrayProps.each( function( prop ) {
-            variables.data[ arguments.prop ] = variables.data[ arguments.prop ].filter( function( value ) {
-                return arguments.value != "__rm__";
-            } );
+			var currentArray = structGet( "variables.data." & prop );
+			updateNestedKey(
+				prop,
+				currentArray.filter( function( value ) {
+					return value != "__rm__";
+				} )
+			);
         } );
 
         // Call onUpdate passing newValues and oldValues
@@ -813,6 +820,30 @@ component output="true" accessors="true" {
             invoke( this, "onUpdate", { newValues: duplicate( variables.data ), oldValues: local.oldValues } );
         }
     }
+
+    /**
+     * update a nested key in the data structure
+     *
+     * @keyPath string | the data property key being updated.
+     * @value any | the value to set in the dot notation nested key.
+     *
+     * @return void
+     */
+	public void function updateNestedKey( required string keyPath, required any value ) {
+        var keys = ListToArray( arguments.keyPath, "." );
+        var current = variables.data;
+        // Loop through keys except the last one to create/traverse nested structure
+        for ( var i = 1; i < keys.Len(); i++ ) {
+            var key = keys[ i ];
+            // Create nested struct if it doesn't exist
+            if ( !current.KeyExists( key ) ) {
+                current[ key ] = {};
+            }
+            // Move to the next level
+            current = current[ key ];
+        }
+        current[ keys[ keys.Len() ] ] = arguments.value;
+    };
 
     /**
      * Validate if key being updated is a locked property.
@@ -943,7 +974,7 @@ component output="true" accessors="true" {
         );
         // Check if the component has an onUploadError method and invoke it
         if ( structKeyExists( this, "onUploadError" ) ) {
-            invoke( this, "onUploadError", { 
+            invoke( this, "onUploadError", {
                 property: arguments.prop,
                 errors: arguments.errors,
                 multiple: arguments.multiple

--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -843,7 +843,7 @@ component output="true" accessors="true" {
             current = current[ key ];
         }
         current[ keys[ keys.Len() ] ] = arguments.value;
-    };
+    }
 
     /**
      * Validate if key being updated is a locked property.

--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -790,14 +790,14 @@ component output="true" accessors="true" {
                 local.arrayIndex = local.regexMatch.match[ 3 ];
 				local.currentArray = structGet( "variables.data." & local.propertyName );
 				local.currentArray[ local.arrayIndex + 1 ] = isNumeric( arguments.value ) ? val( arguments.value ) : arguments.value;
-				updateNestedKey( local.propertyName, local.currentArray );
+				_updateDataValue( local.propertyName, local.currentArray );
 				// Track that we updated an array property
                 if ( !arrayFindNoCase( updatedArrayProps, local.propertyName ) ) {
                     updatedArrayProps.append( local.propertyName );
                 }
             } else {
                 local.oldValue = structGet( "variables.data." & key );
-                updateNestedKey( key, arguments.value );
+                _updateDataValue( key, arguments.value );
 				var onUpdateFunctionName = "onUpdate" & key.replace( ".", "_", "all" );
 				if ( structKeyExists( this, onUpdateFunctionName) ) {
                     invoke( this, onUpdateFunctionName, { value: arguments.value, oldValue: local.oldValue });
@@ -807,7 +807,7 @@ component output="true" accessors="true" {
 
         local.updatedArrayProps.each( function( prop ) {
 			var currentArray = structGet( "variables.data." & prop );
-			updateNestedKey(
+			_updateDataValue(
 				prop,
 				currentArray.filter( function( value ) {
 					return value != "__rm__";
@@ -822,14 +822,14 @@ component output="true" accessors="true" {
     }
 
     /**
-     * update a nested key in the data structure
+     * update a key value in variables.data structure.
      *
-     * @keyPath string | the data property key being updated.
-     * @value any | the value to set in the dot notation nested key.
+     * @keyPath string | the data property key being updated. Supports dot notation for nested structures (e.g., "user.address.street").
+     * @value any | the value to set.
      *
      * @return void
      */
-	public void function updateNestedKey( required string keyPath, required any value ) {
+	public void function _updateDataValue( required string keyPath, required any value ) {
         var keys = ListToArray( arguments.keyPath, "." );
         var current = variables.data;
         // Loop through keys except the last one to create/traverse nested structure

--- a/test-harness/handlers/Workshop.cfc
+++ b/test-harness/handlers/Workshop.cfc
@@ -11,4 +11,6 @@ component {
     function signupForm() {}
 
     function taskList() {}
+
+    function nestedDataKeys() {}
 }

--- a/test-harness/layouts/workshop.cfm
+++ b/test-harness/layouts/workshop.cfm
@@ -24,6 +24,7 @@
                         <li><a href="/workshop/Counter">Counter</a></li>
                         <li><a href="/workshop/SignupForm">Signup Form</a></li>
                         <li><a href="/workshop/TaskList">Task List</a></li>
+                        <li><a href="/workshop/nestedDataKeys">Dot Notation Data</a></li>
                     </ul>
                 </div>
                 <div class="col-9 right-content">
@@ -44,7 +45,7 @@
                 // });
             });
             document.addEventListener("livewire:navigated", () => {
-                
+
             });
         </script>
     </body>

--- a/test-harness/server-adobe@2023.json
+++ b/test-harness/server-adobe@2023.json
@@ -1,19 +1,22 @@
 {
-    "name": "cbwire-adobe@2023",
-    "app": {
-        "serverHomeDirectory": ".engine/adobe2023",
-        "cfengine": "adobe@2023"
+    "name":"cbwire-adobe@2023",
+    "app":{
+        "serverHomeDirectory":".engine/adobe2023",
+        "cfengine":"adobe@2023"
     },
-    "web": {
-        "http": {
-            "port": "60299"
+    "web":{
+        "http":{
+            "port":"60299"
         },
-        "rewrites": {
-            "enable": "true"
+        "rewrites":{
+            "enable":"true"
         },
-        "aliases": {
-            "/modules/cbwire": "../"
+        "aliases":{
+            "/modules/cbwire":"../"
         }
     },
-    "openBrowser": "false"
+    "openBrowser":"false",
+    "scripts":{
+        "onServerInstall":"cfpm install zip"
+    }
 }

--- a/test-harness/server-adobe@2025.json
+++ b/test-harness/server-adobe@2025.json
@@ -1,8 +1,8 @@
 {
-    "name":"cbwire-adobe@2021",
+    "name":"cbwire-adobe@2025",
     "app":{
-        "serverHomeDirectory":".engine/adobe2021",
-        "cfengine":"adobe@2021"
+        "serverHomeDirectory":".engine/adobe2025",
+        "cfengine":"adobe@2025"
     },
     "web":{
         "http":{
@@ -14,6 +14,9 @@
         "aliases":{
             "/modules/cbwire":"../"
         }
+    },
+    "JVM":{
+        "javaVersion":"openjdk21"
     },
     "openBrowser":"false",
     "scripts":{

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -103,9 +103,9 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 var CBWIREController = getInstance( "CBWIREController@cbwire" );
                 var settings = getInstance( "coldbox:modulesettings:cbwire" );
                 settings.updateEndpoint = "/index.bxm/cbwire/update";
-                
+
                 var uploadURL = CBWIREController.generateSignedUploadURL();
-                
+
                 // The URL should contain the custom path
                 expect( uploadURL ).toInclude( "/index.bxm/cbwire/upload" );
                 // It should also contain expires and signature parameters
@@ -833,6 +833,73 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 );
                 var response = cbwireController.handleRequest( payload, event );
                 expect( response.components[1].effects.html ).toInclude( "CBWIRE Slaps!" );
+            } );
+
+            it( "should provide updates to data properties using dot notation", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.test_component_with_dot_notation_data",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {
+                        "title": {
+							"label" : "CBWIRE Rocks!"
+						}
+                    },
+                    calls = [],
+                    updates = {
+                        "title.label": "CBWIRE Slaps!"
+                    }
+                );
+                var response = cbwireController.handleRequest( payload, event );
+                expect( response.components[1].effects.html ).toInclude( "CBWIRE Slaps!" );
+            } );
+
+            it( "should support incoming array values in dot notation referenced array", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.test_component_with_dot_notation_data",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {},
+                    calls = [],
+                    updates = [
+                        "modules.names.0": "CBWIRE",
+                        "modules.names.1": "CBORM",
+                        "modules.names.2": "__rm__"
+                    ]
+                );
+                var response = cbwireController.handleRequest( payload, event );
+                var snapshot = deserializeJson( response.components[ 1 ].snapshot );
+                expect( snapshot.data.modules.names ).toBeArray();
+                expect( snapshot.data.modules.names.len() ).toBe( 2 );
+                expect( snapshot.data.modules.names[ 1 ] ).toBe( "CBWIRE" );
+                expect( snapshot.data.modules.names[ 2 ] ).toBe( "CBORM" );
+            } );
+
+            it( "should call onUpdate[Property_Dot_Notation] if it exists", function() {
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.test_component_with_dot_notation_data",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {
+                        "title": {
+							"label" : "CBWIRE Rocks!"
+						}
+                    },
+                    calls = [],
+                    updates = {
+                        "title.label": "CBWIRE Slaps!"
+                    }
+                );
+                var response = cbwireController.handleRequest( payload, event );
+                expect( response.components[1].effects.html ).toInclude( "CBWIRE Slaps!" );
+                expect( response.components[1].effects.html ).toInclude( "New Value: CBWIRE Slaps!" );
+                expect( response.components[1].effects.html ).toInclude( "Old Value: CBWIRE Rocks!" );
             } );
 
             it( "should dispatch an event without params", function() {
@@ -1846,9 +1913,9 @@ component extends="coldbox.system.testing.BaseTestCase" {
      *
      * @html string | The rendered HTML containing the component.
      * @index numeric | The index of the component if multiple match (usually 1).
-     * 
+     *
      * @return struct The deserialized snapshot struct.
-     * 
+     *
      * @throws Error if parsing or deserialization fails.
      */
     private function parseSnapshot( required string html, numeric index = 1 ) {
@@ -1886,9 +1953,9 @@ component extends="coldbox.system.testing.BaseTestCase" {
      *
      * @html The rendered HTML containing the component.
      * @index The index of the component if multiple match (usually 1).
-     * 
+     *
      * @return any The deserialized effects (usually struct or array).
-     * 
+     *
      * @throws Error if parsing or deserialization fails.
      */
     private function parseEffects( required string html, numeric index = 1 ) {
@@ -1924,9 +1991,9 @@ component extends="coldbox.system.testing.BaseTestCase" {
         }
     }
 
-    /** 
+    /**
      * Check if the current environment is a BoxLang environment
-     * 
+     *
      * @return boolean
      */
     private function isBoxLang() {

--- a/test-harness/views/workshop/nestedDataKeys.cfm
+++ b/test-harness/views/workshop/nestedDataKeys.cfm
@@ -1,0 +1,1 @@
+<cfoutput>#wire( "workshop.NestedDataKeys" )#</cfoutput>

--- a/test-harness/wires/test/test_component_with_dot_notation_data.cfm
+++ b/test-harness/wires/test/test_component_with_dot_notation_data.cfm
@@ -1,0 +1,40 @@
+<cfscript>
+    // @startWire
+    data = {
+		"title": {
+			"label" : "CBWIRE Rocks!"
+		},
+        "newValue": "",
+        "oldValue": "",
+		"modules": {
+			"names" : [
+				"Module 1",
+				"Module 2",
+				"Module 3"
+			]
+		}
+    };
+
+    function onUpdatetitle_label( value, oldValue ) {
+        data.title.label = arguments.value;
+        data.newValue = arguments.value;
+        data.oldValue = arguments.oldValue;
+    }
+    // @endWire
+</cfscript>
+
+<cfoutput>
+    <div>
+        <h1>Title: #title.label#</h1>
+        <p>New Value: #newValue#</p>
+        <p>Old Value: #oldValue#</p>
+        <cfif modules.names.len()>
+            <ul>
+                <cfloop array="#modules.names#" index="module">
+                    <li>#module#</li>
+                </cfloop>
+            </ul>
+        </cfif>
+
+    </div>
+</cfoutput>

--- a/test-harness/wires/workshop/NestedDataKeys.cfc
+++ b/test-harness/wires/workshop/NestedDataKeys.cfc
@@ -1,0 +1,25 @@
+component extends="cbwire.models.Component" {
+    data = {
+        "user": {
+			"name": {
+				"first": "John",
+				"last": "Doe"
+			},
+			"email": "jdoe@ortus.local",
+			"address": {
+				"street": "123 Main St",
+				"city": "Severn",
+				"state": "MD",
+				"zip": "12345"
+			},
+			"roles" : [ "editor" ]
+		},
+		"showSuccess": false
+    };
+
+	function submit() {
+		data.showSuccess = true;
+    }
+
+
+}

--- a/test-harness/wires/workshop/NestedDataKeys.cfm
+++ b/test-harness/wires/workshop/NestedDataKeys.cfm
@@ -1,0 +1,87 @@
+<cfoutput>
+    <div>
+        <h1>Dot Notation Data Properties</h1>
+
+		<cfif showSuccess >
+			<div class="alert alert-success" role="alert">
+				<h3>Form submitted successfully!</h3>
+				<strong>Data Submitted:</strong><br>
+				First Name: #user.name.first#<br>
+				Last Name: #user.name.last#<br>
+				Email: #user.email#<br>
+				Address: #user.address.street#<br>
+				City: #user.address.city#<br>
+				State: #user.address.state#<br>
+				Zip: #user.address.zip#<br>
+				Roles: #ArrayToList(user.roles)#<br>
+			</div>
+		</cfif>
+
+		<form class="row g-3" wire:submit.prevent="submit" >
+
+			<h3 class="border-bottom">User Info</h3>
+
+			<div class="col-md-6">
+				<label class="form-label">First Name</label>
+				<input type="text" class="form-control" wire:model="user.name.first">
+			</div>
+
+			<div class="col-md-6">
+				<label class="form-label">Last Name</label>
+				<input type="text" class="form-control" wire:model="user.name.last">
+			</div>
+
+
+			<div class="col-md-6">
+				<label class="form-label">Email</label>
+				<input type="email" class="form-control"  wire:model="user.email">
+			</div>
+
+			<div class="col-12">
+				<label class="form-label">Address</label>
+				<input type="text" class="form-control" wire:model="user.address.street">
+			</div>
+
+			<div class="col-md-6">
+				<label class="form-label">City</label>
+				<input type="text" class="form-control" wire:model="user.address.city">
+			</div>
+
+			<div class="col-md-4">
+				<label class="form-label">State</label>
+				<input type="text" class="form-control" wire:model="user.address.state">
+			</div>
+
+			<div class="col-md-2">
+				<label class="form-label">Zip</label>
+				<input type="text" class="form-control" wire:model="user.address.zip">
+			</div>
+
+			<h3 class="border-bottom">User Roles</h3>
+
+			<div class="col-md-12">
+
+				<div class="form-check form-check-inline">
+					<input class="form-check-input" type="checkbox" id="inlineCheckbox1" value="admin" wire:model="user.roles">
+					<label class="form-check-label" for="inlineCheckbox1">Admin</label>
+				</div>
+
+				<div class="form-check form-check-inline">
+					<input class="form-check-input" type="checkbox" id="inlineCheckbox2" value="editor" wire:model="user.roles">
+					<label class="form-check-label" for="inlineCheckbox2">Editor</label>
+				</div>
+
+				<div class="form-check form-check-inline">
+					<input class="form-check-input" type="checkbox" id="inlineCheckbox3" value="auditor" wire:model="user.roles">
+					<label class="form-check-label" for="inlineCheckbox3">Auditor</label>
+				</div>
+
+			</div>
+
+			<div class="col-12">
+				<button type="submit" class="btn btn-primary">Save</button>
+			</div>
+
+		</form>
+    </div>
+</cfoutput>


### PR DESCRIPTION
Livewire.js already supports dot notation for data properties on the client. This adds server functionality to handle those dot notation keys in your wire.

For Example:

*YourWire.cfc Data properties*

```
data = {
    "user": {
        "name": {
            "first": "John",
            "last": "Doe"
        }
    }
};
```

*YourWire.cfm inputs with wire:model*

```
<input type="text"  wire:model="user.name.first">
<input type="text"  wire:model="user.name.last">
```

* * *

# Changes/Additions

##### changes to `_applyUpdates( updates )` function ( models/Component.cfc )

- Uses native `structGet()` to retrieve values from data properties since it already supports got notation
- Uses new `_updateDataValue()` function to update data property values

*Note for OnUdpate\[ Property \] LifeCycle Events:*

Creates `onUpdate[ Property ]` lifecycle events for nested keys by changing dots to underscores, thus the `onUpdate[ Property ]` lifecycle event for `user.name.first` would be `onUpdateuser_name_first( newValue, oldValue )`

##### Added `_updateDataValue( keyPath, value )` function ( models/Component.cfc )

- takes two arguments `keyPath` & `value`
- handles dot notation keys (i.e. `user.address.zip`) and single depth keys (i.e. `roles`)
- converts `keyPath` argument into an array (if not dot notation it is a single value array) and loops over the array of keys to traverse the data properties to get to the target data property and sets the value to the provided `value` argument
- Will create keys if they do not exists

### TestBox Tests

Adds three tests for functionality. As a note, all other tests are now also using `structGet()` for retrieval of data properties and `_updateDataValue( keyPath, value )` for setting data properties.

- `should provide updates to data properties using dot notation`
- `should support incoming array values in dot notation referenced array`
- `should call onUpdate[Property_Dot_Notation] if it exists`

### Added Example

Adds an example wire in the Workshop examples used for the ITB 2024 workshop found at `http://127.0.0.1:60299/workshop` when the test-harness servers are run. This example uses multiple nested data property keys as well as a nested array for checkboxes.

### Other Minor Changes

##### .gitignore

- Added `views/tmp/**` since the test harness created a handful of temporary view files it wanted to include in the commits
- Added `.DS_Store` since I work on a mac and it wanted to include all these auto created on my mac

### Server .json files Updates for ACF

- Added a server-adobe@2025.json file for testing on ACF 2025
- The test-harness server, when running ACF needs the `zip` package and errors until installed. I added the CFPM entry to install this on startup