### PR TITLE
Interceptors

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -63,7 +63,7 @@ component {
             "progressBarColor": "##2299dd",
             /**
              * Enables or disables checksum validation for component payloads.
-             * We recommend always leaving this enabled, but you can disable it 
+             * We recommend always leaving this enabled, but you can disable it
              * as needed.
              */
             "checksumValidation": true
@@ -93,7 +93,13 @@ component {
         ];
 
         interceptorSettings = {
-            customInterceptionPoints : []
+            customInterceptionPoints : [
+				"cbWireOnMount",
+				"cbWirePreRender",
+				"cbWireOnRender",
+				"cbWirePreUpdate",
+				"cbWireOnUpdate"
+			]
         };
     }
 

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -94,11 +94,11 @@ component {
 
         interceptorSettings = {
             customInterceptionPoints : [
-				"cbWireOnMount",
-				"cbWirePreRender",
-				"cbWireOnRender",
-				"cbWirePreUpdate",
-				"cbWireOnUpdate"
+				"onCBWIREMount",
+				"preCBWIRERender",
+				"onCBWIRERender",
+				"preCBWIREUpdate",
+				"onCBWIREUpdate"
 			]
         };
     }

--- a/models/CBWIREController.cfc
+++ b/models/CBWIREController.cfc
@@ -71,9 +71,9 @@ component accessors="true" singleton {
         // Perform initial deserialization of the incoming request payload
         local.payload = deserializeJSON( arguments.incomingRequest.content );
 
-		// Announce the cbWirePreUpdate event to global interceptors
+		// Announce the preCBWIREUpdate event to global interceptors
 		variables.interceptorService.announce(
-			"cbWirePreUpdate",
+			"preCBWIREUpdate",
 			{
 				"payload" : local.payload
 			}
@@ -109,9 +109,9 @@ component accessors="true" singleton {
             } )
         };
 
-		// Announce the cbWireOnUpdate event to global interceptors
+		// Announce the onCBWIREUpdate event to global interceptors
 		variables.interceptorService.announce(
-			"cbWireOnUpdate",
+			"onCBWIREUpdate",
 			{
 				"payload" : local.payload,
 				"response" : local.componentsResult
@@ -352,15 +352,15 @@ component accessors="true" singleton {
         throw("ApplicationException", "Unable to instantiate component '#arguments.name#'. Detail: #e.message#");
     }
 
-    /**
-    * Returns the path to the modules folder.
-    *
-    * @module string | The name of the module.
-    *
-    * @return string
-	*
-	* @throws ModuleNotFound If the specified module does not exist.
-    */
+	/**
+     * Returns the path to the modules folder.
+     *
+     * @module string | The name of the module.
+     *
+     * @return string
+	 *
+	 * @throws ModuleNotFound If the specified module does not exist.
+     */
     function getModuleRootPath( module ) {
         var moduleRegistry = moduleService.getModuleRegistry();
 

--- a/models/CBWIREController.cfc
+++ b/models/CBWIREController.cfc
@@ -21,11 +21,15 @@ component accessors="true" singleton {
     // Inject ChecksumService
     property name="checksumService" inject="ChecksumService@cbwire";
 
+	// Inject interceptorService
+	property name="interceptorService" inject="coldbox:interceptorService";
+
     function init() {
         // Initialize the array to store single file components
         variables._singleFileComponents = [];
         return this;
     }
+
     /**
      * Instantiates a CBWIRE component, mounts it,
      * and then calls its onRender() method.
@@ -66,6 +70,15 @@ component accessors="true" singleton {
         };
         // Perform initial deserialization of the incoming request payload
         local.payload = deserializeJSON( arguments.incomingRequest.content );
+
+		// Announce the cbWirePreUpdate event to global interceptors
+		variables.interceptorService.announce(
+			"cbWirePreUpdate",
+			{
+				"payload" : local.payload
+			}
+		);
+
         // Set the CSRF token for the request
         local.csrfToken = local.payload._token;
         // Validate the CSRF token
@@ -74,12 +87,14 @@ component accessors="true" singleton {
         if( !local.csrfTokenVerified ){
             throw( type="CBWIREException", message="Page expired." );
         }
+
         // Perform additional deserialization of the component snapshots
         local.payload.components = local.payload.components.map( function( _comp ) {
             checksumService.validateChecksum( arguments._comp.snapshot );
             arguments._comp.snapshot = deserializeJSON( arguments._comp.snapshot );
             return arguments._comp;
         } );
+
         // Iterate over each component in the payload and process it
         local.componentsResult = {
             "components": local.payload.components.map( ( _componentPayload ) => {
@@ -93,6 +108,15 @@ component accessors="true" singleton {
                             ._getHTTPResponse( _componentPayload, httpRequestState );
             } )
         };
+
+		// Announce the cbWireOnUpdate event to global interceptors
+		variables.interceptorService.announce(
+			"cbWireOnUpdate",
+			{
+				"payload" : local.payload,
+				"response" : local.componentsResult
+			}
+		);
 
         // Return assets from components
         if ( local.httpRequestState.assets.count() ) {
@@ -224,9 +248,9 @@ component accessors="true" singleton {
 
     /**
      * Converts a component DSL from dot notation to slash notation.
-     * 
+     *
      * @componentDSL String | The component DSL to convert.
-     * 
+     *
      * @return String | The converted DSL in slash notation.
      */
     function convertDSLToSlashNotation( componentDSL ) {
@@ -235,9 +259,9 @@ component accessors="true" singleton {
 
     /**
      * Returns true if the component DSL is a module DSL.
-     * 
+     *
      * @componentDSL String | The component DSL to check.
-     * 
+     *
      * @return boolean
      */
     function isModuleDSL( componentDSL ) {
@@ -255,12 +279,12 @@ component accessors="true" singleton {
         return expandPath( "/" & local.dslSlashNotation);
     }
 
-    /** 
+    /**
      * Returns true if the component is a single file component.
      * Also provides a performance optimization by checking if the component is already flagged as a single file component.
-     * 
+     *
      * @componentDSL String | The component DSL to check.
-     * 
+     *
      * @return boolean
      */
     function isSingleFileComponent( componentDSL ) {
@@ -272,7 +296,7 @@ component accessors="true" singleton {
         local.dslFilePathWithoutExtension = getDSLFilePathWithoutExtension( componentDSL );
 
         if ( !fileExists( local.dslFilePathWithoutExtension & ".bx" ) && !fileExists( local.dslFilePathWithoutExtension & ".cfc" ) ) {
-            if ( fileExists( local.dslFilePathWithoutExtension & ".bxm" ) || fileExists( local.dslFilePathWithoutExtension & ".cfm" ) ) {                
+            if ( fileExists( local.dslFilePathWithoutExtension & ".bxm" ) || fileExists( local.dslFilePathWithoutExtension & ".cfm" ) ) {
                 variables._singleFileComponents.append( componentDSL );
                 return true;
             }
@@ -313,7 +337,7 @@ component accessors="true" singleton {
      * @name String | The name of the component to instantiate.
      *
      * @return The instantiated component object.
-     * 
+     *
      * @throws ApplicationException If the component cannot be found or instantiated.
      */
     function createInstance( name ) {
@@ -325,7 +349,7 @@ component accessors="true" singleton {
             return createRegularComponent( local.componentDSL, arguments.name );
         }
 
-            throw("ApplicationException", "Unable to instantiate component '#arguments.name#'. Detail: #e.message#");
+        throw("ApplicationException", "Unable to instantiate component '#arguments.name#'. Detail: #e.message#");
     }
 
     /**
@@ -334,6 +358,8 @@ component accessors="true" singleton {
     * @module string | The name of the module.
     *
     * @return string
+	*
+	* @throws ModuleNotFound If the specified module does not exist.
     */
     function getModuleRootPath( module ) {
         var moduleRegistry = moduleService.getModuleRegistry();

--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -458,7 +458,7 @@ component output="true" accessors="true" {
      * @return
      */
     function reset( property ){
-        // if no proeprty argument get array of all data keys (in dot notation when appropriate)
+        // if no property argument get array of all data keys (in dot notation when appropriate)
         if ( isNull( arguments.property ) )
 			arguments.property = _getDotNotationKeys();
 

--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -1,5 +1,7 @@
 component output="true" accessors="true" {
 
+	property name="_interceptorService" inject="coldbox:interceptorService";
+
     property name="_configService" inject="provider:ConfigService@cbwire";
 
     property name="_CBWIREController" inject="provider:CBWIREController@cbwire";
@@ -449,53 +451,50 @@ component output="true" accessors="true" {
 
     /**
      * Resets a data property to it's initial value.
-     * Can be used to reset all data properties, a single data property, or an array of data properties.
+     * Can be used to reset all data properties, a single data property, an array, or comma seperated list of data properties.
+	 *
+	 * @property string|list|array | The property or properties to reset. If null, all properties will be reset.
      *
      * @return
      */
     function reset( property ){
-        if ( isNull( arguments.property ) ) {
-            // Reset all properties
-            variables.data.each( function( key, value ){
-                reset( key );
-            } );
-        } else if ( isArray( arguments.property ) ) {
-            // Reset each property in our array individually
-            arguments.property.each( function( prop ){
-                reset( prop );
-            } );
-        } else {
-            var initialState = variables._initialDataProperties;
-            // Reset individual property (only if it exists in initial state)
-            if ( initialState.keyExists( arguments.property ) ) {
-                variables.data[ arguments.property ] = initialState[ arguments.property ];
-            } else {
-                // Property doesn't exist in initial state, set to empty string
-                variables.data[ arguments.property ] = "";
-            }
-        }
+        // if no proeprty argument get array of all data keys (in dot notation when appropriate)
+        if ( isNull( arguments.property ) )
+			arguments.property = _getDotNotationKeys();
+
+		// convert comma separated list to array ( single key string becomes single item array )
+		arguments.property = !isArray( arguments.property ) ? listToArray( arguments.property, "," ) : arguments.property;
+
+		// reset all data properties
+		arguments.property.each( function( element, index ) {
+			var initialValue = structGet( "variables._initialDataProperties." & element );
+			if( isStruct( initialValue ) )
+				initialValue = "";
+			_updateDataValue( element, initialValue );
+		});
     }
 
     /**
      * Resets all data properties except the ones specified.
+	 *
+	 * @property string|list|array | The property or properties to NOT reset.
      *
      * @return void
+	 * @throws ResetException
      */
     function resetExcept( property ){
-        if ( isNull( arguments.property ) ) {
+        if ( isNull( arguments.property ) )
             throw( type="ResetException", message="Cannot reset a null property." );
-        }
-
-        // Reset all properties except what was provided
-        _getDataProperties().each( function( key, value ){
-            if ( isArray( property ) ) {
-                if ( !arrayFindNoCase( property, arguments.key ) ) {
-                    reset( key );
-                }
-            } else if ( property != key ) {
-                reset( key );
-            }
-        } );
+		// convert comma separated list to array ( single key string becomes single item array )
+		arguments.property = !isArray( arguments.property ) ? listToArray( arguments.property, "," ) : arguments.property;
+        // Get all data property keys
+		var resetKeys = _getDotNotationKeys();
+		// remove provided properties from reset keys array
+		for( var removeKey in arguments.property ) {
+			resetKeys.delete( removeKey );
+		}
+        // Reset all properties except what was removed above
+		reset( resetKeys );
     }
 
     /**
@@ -668,6 +667,17 @@ component output="true" accessors="true" {
             }
         }
 
+		// Announce the cbWireOnMount event to global interceptors
+		variables._interceptorService.announce(
+			"cbWireOnMount",
+			{
+				"lazy" 		: false,
+				"params" 	: arguments.params,
+				"wire"		: this,
+				"wireName"	: variables._path,
+				"wireData"	: variables.data
+			}
+		);
 
         return this;
     }
@@ -849,6 +859,30 @@ component output="true" accessors="true" {
         }
         current[ keys[ keys.Len() ] ] = arguments.value;
     }
+
+	/**
+	 * Recursively retrieves all keys from a struct in dot notation.
+	 *
+	 * @inputStruct struct | The input struct to retrieve keys from.
+	 * @prefix string | The prefix for nested keys (used in recursion).
+	 *
+	 * @return array | An array of keys in dot notation.
+	 */
+	public array function _getDotNotationKeys( struct inputStruct, string prefix="" ) {
+		if( isNull( arguments.inputStruct ) )
+			arguments.inputStruct = variables.data;
+		var result = [];
+		for ( var key in inputStruct.keyArray() ) {
+			var fullKey = ( prefix == "" ) ? key : prefix & "." & key;
+			var value = inputStruct[ key ];
+			if ( isStruct( value ) ) {
+				result.append( _getDotNotationKeys( value, fullKey ), true )
+			} else {
+				result.append( fullKey );
+			}
+		}
+		return result;
+	}
 
     /**
      * Validate if key being updated is a locked property.
@@ -1057,6 +1091,19 @@ component output="true" accessors="true" {
                 params=local.mountParams
             );
         }
+
+		// Announce the cbWireOnMount event to global interceptors
+		variables._interceptorService.announce(
+			"cbWireOnMount",
+			{
+				"lazy"		: true,
+				"snapshot"	: local.decodedSnapshot,
+				"params" 	: local.mountParams,
+				"wire"		: this,
+				"wireName"	: variables._path,
+				"wireData"	: variables.data
+			}
+		);
     }
 
     /**
@@ -1466,14 +1513,35 @@ component output="true" accessors="true" {
      * Response for actually starting rendering of a component.
      */
     function _render( rendering ) {
+
+		variables._interceptorService.announce(
+			"cbWirePreRender",
+			{
+				"wire"		: this,
+				"wireName"	: variables._path,
+				"wireData"	: variables.data
+			}
+		);
+
         local.trimmedHTML = isNull( arguments.rendering ) ? trim( onRender() ) : trim( arguments.rendering );
-        return variables._renderService.render( this, local.trimmedHTML );
+		var renderedContent = variables._renderService.render( this, local.trimmedHTML );
+
+		variables._interceptorService.announce(
+			"cbWireOnRender",
+			{
+				"wire"		: this,
+				"wireName"	: variables._path,
+				"wireData"	: variables.data,
+				"wireHTML"	: renderedContent
+			}
+		);
+
+		return renderedContent;
     }
 
     function _trackScript( required scriptTagId, required scriptContent ) {
         variables._scripts[ scriptTagId ] = scriptContent;
     }
-
 
     function _trackAsset( required assetTagId, required assetContent ) {
         variables._assets[ assetTagId ] = assetContent;

--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -667,17 +667,9 @@ component output="true" accessors="true" {
             }
         }
 
-		// Announce the cbWireOnMount event to global interceptors
-		variables._interceptorService.announce(
-			"cbWireOnMount",
-			{
-				"lazy" 		: false,
-				"params" 	: arguments.params,
-				"wire"		: this,
-				"wireName"	: variables._path,
-				"wireData"	: variables.data
-			}
-		);
+		// Announce the onCBWIREMount event to global interceptors
+		_fireInterceptorEvent( "onCBWIREMount", { "params" : arguments.params, "lazy" : false} );
+
 
         return this;
     }
@@ -1092,18 +1084,9 @@ component output="true" accessors="true" {
             );
         }
 
-		// Announce the cbWireOnMount event to global interceptors
-		variables._interceptorService.announce(
-			"cbWireOnMount",
-			{
-				"lazy"		: true,
-				"snapshot"	: local.decodedSnapshot,
-				"params" 	: local.mountParams,
-				"wire"		: this,
-				"wireName"	: variables._path,
-				"wireData"	: variables.data
-			}
-		);
+		// Announce the onCBWIREMount event to global interceptors
+		_fireInterceptorEvent( "onCBWIREMount", { "params" : local.mountParams, "lazy" : true } );
+
     }
 
     /**
@@ -1513,28 +1496,12 @@ component output="true" accessors="true" {
      * Response for actually starting rendering of a component.
      */
     function _render( rendering ) {
-
-		variables._interceptorService.announce(
-			"cbWirePreRender",
-			{
-				"wire"		: this,
-				"wireName"	: variables._path,
-				"wireData"	: variables.data
-			}
-		);
+		_fireInterceptorEvent( "preCBWIRERender" );
 
         local.trimmedHTML = isNull( arguments.rendering ) ? trim( onRender() ) : trim( arguments.rendering );
 		var renderedContent = variables._renderService.render( this, local.trimmedHTML );
 
-		variables._interceptorService.announce(
-			"cbWireOnRender",
-			{
-				"wire"		: this,
-				"wireName"	: variables._path,
-				"wireData"	: variables.data,
-				"wireHTML"	: renderedContent
-			}
-		);
+		_fireInterceptorEvent( "onCBWIRERender", { "html" : renderedContent } );
 
 		return renderedContent;
     }
@@ -1550,4 +1517,31 @@ component output="true" accessors="true" {
     function _getCompileTimeKey() {
         return variables._compileTimeKey;
     }
+
+	/**
+	 * Fires an interceptor event.
+	 * Standardizes data passed to interceptors fired from base wire Component.cfc
+	 * ensure consistent data structure. Includes wire, wireName, wireData, and meta in eventData.
+	 *
+	 * @eventName string | The name of the event to fire.
+	 * @eventData struct | Additional data to pass to the interceptor.
+	 *
+	 * @return void
+	 */
+	function _fireInterceptorEvent( eventName, eventData={} ) {
+		// append standard data to eventData struct, but do NOT overwrite existing keys
+		arguments.eventData.append(
+			{
+				"wire"		: this,
+				"wireName"	: variables._path,
+				"wireData"	: variables.data,
+				"meta"		: variables._metaData
+			},
+			false
+		);
+		return variables._interceptorService.announce(
+			arguments.eventName,
+			arguments.eventData
+		);
+	}
 }

--- a/test-harness/config/Coldbox.cfc
+++ b/test-harness/config/Coldbox.cfc
@@ -51,9 +51,9 @@ component{
 			exclude = []
 		};
 
-		//Register interceptors as an array, we need order
+		//Register interceptors as an array, we need order*/
 		interceptors = [
-			{ class="cbwire.interceptors.CBWIRE" }
+			{ class="interceptors.TestHarnessInterceptor" }
 		];
 
 		layoutSettings = {
@@ -118,6 +118,8 @@ component{
 		} catch ( any e ) {
 			writeDump( var=e, output="console" );
 		}
+		// rescan interceptors to pick up the test harness interceptors for cbwire
+		controller.getWirebox().getInstance( "coldbox:interceptorService" ).rescanInterceptors();
 	}
 
 }

--- a/test-harness/handlers/Workshop.cfc
+++ b/test-harness/handlers/Workshop.cfc
@@ -12,5 +12,10 @@ component {
 
     function taskList() {}
 
-    function nestedDataKeys() {}
+    function nestedDataKeys() {
+		// Clear any previously run interceptors
+		lock name="clearEventInterceptorKey" timeout="1" {
+			application.delete( "cbwire_interceptors_run" );
+		}
+	}
 }

--- a/test-harness/interceptors/TestHarnessInterceptor.cfc
+++ b/test-harness/interceptors/TestHarnessInterceptor.cfc
@@ -2,31 +2,48 @@ component {
 
 	property name="log" inject="logbox:root";
 
-	function cbWireOnMount() {
-		log.debug( "cbWireOnMount called in TestHarnessInterceptor FIRED" );
-		// throw( type="CBWIREException", message="Failure when calling cbWireOnMount() interceptor." );
+	function onCBWIREMount() {
+		log.debug( "onCBWIREMount called in TestHarnessInterceptor FIRED" );
+		logRunningEventInterceptor( "onCBWIREMount" );
+		// throw( type="CBWIREException", message="Failure when calling onCBWIREMount() interceptor." );
 	}
 
-	function cbWirePreRender() {
-		log.debug( "cbWirePreRender called in TestHarnessInterceptor FIRED" );
-		// throw( type="CBWIREException", message="Failure when calling cbWirePreRender() interceptor." );
+	function preCBWIRERender() {
+		log.debug( "preCBWIRERender called in TestHarnessInterceptor FIRED" );
+		logRunningEventInterceptor( "preCBWIRERender" );
+		// throw( type="CBWIREException", message="Failure when calling preCBWIRERender() interceptor." );
 	}
 
-	function cbWireOnRender() {
-		log.debug( "cbWireOnRender called in TestHarnessInterceptor FIRED" );
-		// throw( type="CBWIREException", message="Failure when calling cbWireOnRender() interceptor." );
+	function onCBWIRERender() {
+		log.debug( "onCBWIRERender called in TestHarnessInterceptor FIRED" );
+		logRunningEventInterceptor( "onCBWIRERender" );
+		// throw( type="CBWIREException", message="Failure when calling onCBWIRERender() interceptor." );
 	}
 
-	function cbWirePreUpdate() {
-		log.debug( "cbWirePreUpdate called in TestHarnessInterceptor FIRED" );
-		// throw( type="CBWIREException", message="Failure when calling cbWirePreUpdate() interceptor." );
+	function preCBWIREUpdate() {
+		log.debug( "preCBWIREUpdate called in TestHarnessInterceptor FIRED" );
+		logRunningEventInterceptor( "preCBWIREUpdate" );
+		// throw( type="CBWIREException", message="Failure when calling preCBWIREUpdate() interceptor." );
 		return false;
 	}
 
-	function cbWireOnUpdate() {
-		log.debug( "cbWireOnUpdate called in TestHarnessInterceptor FIRED" );
-		// throw( type="CBWIREException", message="Failure when calling cbWireOnUpdate() interceptor." );
+	function onCBWIREUpdate() {
+		log.debug( "onCBWIREUpdate called in TestHarnessInterceptor FIRED" );
+		logRunningEventInterceptor( "onCBWIREUpdate" );
+		// throw( type="CBWIREException", message="Failure when calling onCBWIREUpdate() interceptor." );
 		return false;
+	}
+
+	private function logRunningEventInterceptor( interceptorName ){
+		lock name="logRunningEventInterceptor" timeout="1" {
+			if( !application.keyExists( "cbwire_interceptors_run" ) ){
+				application.cbwire_interceptors_run = {};
+			}
+			application.cbwire_interceptors_run[ arguments.interceptorName ] = {
+				"interceptor" = arguments.interceptorName,
+				"timestamp"   = now()
+			};
+		}
 	}
 
 }

--- a/test-harness/interceptors/TestHarnessInterceptor.cfc
+++ b/test-harness/interceptors/TestHarnessInterceptor.cfc
@@ -1,0 +1,32 @@
+component {
+
+	property name="log" inject="logbox:root";
+
+	function cbWireOnMount() {
+		log.debug( "cbWireOnMount called in TestHarnessInterceptor FIRED" );
+		// throw( type="CBWIREException", message="Failure when calling cbWireOnMount() interceptor." );
+	}
+
+	function cbWirePreRender() {
+		log.debug( "cbWirePreRender called in TestHarnessInterceptor FIRED" );
+		// throw( type="CBWIREException", message="Failure when calling cbWirePreRender() interceptor." );
+	}
+
+	function cbWireOnRender() {
+		log.debug( "cbWireOnRender called in TestHarnessInterceptor FIRED" );
+		// throw( type="CBWIREException", message="Failure when calling cbWireOnRender() interceptor." );
+	}
+
+	function cbWirePreUpdate() {
+		log.debug( "cbWirePreUpdate called in TestHarnessInterceptor FIRED" );
+		// throw( type="CBWIREException", message="Failure when calling cbWirePreUpdate() interceptor." );
+		return false;
+	}
+
+	function cbWireOnUpdate() {
+		log.debug( "cbWireOnUpdate called in TestHarnessInterceptor FIRED" );
+		// throw( type="CBWIREException", message="Failure when calling cbWireOnUpdate() interceptor." );
+		return false;
+	}
+
+}

--- a/test-harness/server-adobe@2021.json
+++ b/test-harness/server-adobe@2021.json
@@ -12,7 +12,8 @@
             "enable":"true"
         },
         "aliases":{
-            "/modules/cbwire":"../"
+            "/modules/cbwire":"../",
+            "/moduleroot/cbwire":"../"
         }
     },
     "openBrowser":"false",

--- a/test-harness/server-adobe@2023.json
+++ b/test-harness/server-adobe@2023.json
@@ -12,7 +12,8 @@
             "enable":"true"
         },
         "aliases":{
-            "/modules/cbwire":"../"
+            "/modules/cbwire":"../",
+            "/moduleroot/cbwire":"../"
         }
     },
     "openBrowser":"false",

--- a/test-harness/server-adobe@2025.json
+++ b/test-harness/server-adobe@2025.json
@@ -12,7 +12,8 @@
             "enable":"true"
         },
         "aliases":{
-            "/modules/cbwire":"../"
+            "/modules/cbwire":"../",
+            "/moduleroot/cbwire":"../"
         }
     },
     "JVM":{

--- a/test-harness/server-boxlang-cfml@1.json
+++ b/test-harness/server-boxlang-cfml@1.json
@@ -12,7 +12,8 @@
             "enable":"true"
         },
         "aliases":{
-            "/modules/cbwire":"../"
+            "/modules/cbwire":"../",
+            "/moduleroot/cbwire":"../"
         }
     },
     "openBrowser":"false",

--- a/test-harness/server-lucee@5.json
+++ b/test-harness/server-lucee@5.json
@@ -12,7 +12,8 @@
             "enable":"true"
         },
         "aliases":{
-            "/modules/cbwire":"../"
+            "/modules/cbwire":"../",
+            "/moduleroot/cbwire":"../"
         }
     },
     "openBrowser":"false"

--- a/test-harness/server-lucee@6.json
+++ b/test-harness/server-lucee@6.json
@@ -12,7 +12,8 @@
             "enable":"true"
         },
         "aliases":{
-            "/modules/cbwire":"../"
+            "/modules/cbwire":"../",
+            "/moduleroot/cbwire":"../"
         }
     },
     "openBrowser":"false",

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -8,7 +8,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
             directoryDelete( local.tempFolder, true );
         }
         directoryCreate( local.tempFolder );
-        
+
         // Clean out uploads temp directory
         local.uploadsTempFolder = getTempDirectory() & "/cbwire";
         if ( directoryExists( local.uploadsTempFolder ) ) {
@@ -1851,6 +1851,60 @@ component extends="coldbox.system.testing.BaseTestCase" {
             });
 
         } );
+
+        describe("Event Interceptors", function() {
+
+            beforeEach(function(currentSpec) {
+                // Assuming setup() initializes application environment
+                // and prepareMock() is a custom method to mock any dependencies, if necessary.
+				// Clear any previously run interceptors
+				lock name="clearEventInterceptorKey" timeout="1" {
+					application.delete( "cbwire_interceptors_run" );
+				}
+                setup();
+                cbwireController = getInstance("CBWIREController@cbwire");
+                event = getRequestContext();
+                prepareMock( cbwireController );
+            });
+
+            it( "should fire the onCBWIREMount, preCBWIRERender, and onCBWIRERender when mounting a wire", function () {
+                var result = CBWIREController.wire( "test.should_render_a_component" );
+                expect( application ).toHaveKey( "cbwire_interceptors_run" );
+				expect( application.cbwire_interceptors_run ).toHaveKey( "onCBWIREMount" );
+				expect( application.cbwire_interceptors_run ).toHaveKey( "preCBWIRERender" );
+				expect( application.cbwire_interceptors_run ).toHaveKey( "onCBWIRERender" );
+				expect( application.cbwire_interceptors_run.keyArray().len() ).toBe( 3 );
+			} );
+
+            it( "should fire the preCBWIRERender, onCBWIRERender, preCBWIREUpdate and onCBWIREUpdate during a wire update incoming request", () => {
+                var settings = getInstance( "coldbox:modulesettings:cbwire" );
+                settings.trimStringValues = true;
+                var payload = incomingRequest(
+                    memo = {
+                        "name": "test.should_trim_string_values_if_global_setting_enabled",
+                        "id": "Z1Ruz1tGMPXSfw7osBW2",
+                        "children": []
+                    },
+                    data = {
+                        "name": "Jane Doe "
+                    },
+                    calls = [],
+                    updates = {
+                        "name": " Jane Doe "
+                    }
+                );
+                var result = cbwireController.handleRequest( payload, event );
+                expect( application ).toHaveKey( "cbwire_interceptors_run" );
+				expect( application.cbwire_interceptors_run ).toHaveKey( "preCBWIRERender" );
+				expect( application.cbwire_interceptors_run ).toHaveKey( "onCBWIRERender" );
+				expect( application.cbwire_interceptors_run ).toHaveKey( "preCBWIREUpdate" );
+				expect( application.cbwire_interceptors_run ).toHaveKey( "onCBWIREUpdate" );
+				expect( application.cbwire_interceptors_run.keyArray().len() ).toBe( 4 );
+            } );
+
+		} );
+
+
     }
 
     /**

--- a/test-harness/views/workshop/nestedDataKeys.cfm
+++ b/test-harness/views/workshop/nestedDataKeys.cfm
@@ -1,1 +1,12 @@
 <cfoutput>#wire( "workshop.NestedDataKeys" )#</cfoutput>
+<cfif application.keyExists( "cbwire_interceptors_run" ) >
+	<hr>
+	<div class="alert alert-info" role="alert">
+	The cfdump below is NOT coming from the wire component, but from the nestedDataKeys.cfm view after the wire has rendered.<br>
+	It shows any CBWire interceptors that ran during the wire lifecycle for this inital page render.<br>
+	The data is being injected into the application scope by the TestHarnessInterceptor.cfc interceptor.<br>
+	The application.cbwire_interceptors_run structure is cleared at the start of the Workshop.nestedDataKeys() handler method to ensure only the interceptors for this wire are shown.
+	</div>
+	<h3>CBWire Interceptors That Ran:</h3>
+	<cfdump var="#application.cbwire_interceptors_run#" label="application.cbwire_interceptors_run" />
+</cfif>

--- a/test-harness/wires/workshop/NestedDataKeys.cfc
+++ b/test-harness/wires/workshop/NestedDataKeys.cfc
@@ -12,14 +12,44 @@ component extends="cbwire.models.Component" {
 				"state": "MD",
 				"zip": "12345"
 			},
-			"roles" : [ "editor" ]
+			"roles" : [ "editor" ],
+			"subscriptions" : {
+				"newsletter" : true,
+				"alerts" : false
+			}
 		},
 		"showSuccess": false
     };
 
+	function resetDataAll() {
+        reset(); // Reverts all data to initial state
+    }
+
+	function resetDataKey( key ){
+		// accepts nested keys like 'user.address.street'
+		reset( key );
+	}
+
+	function resetExceptDataKey( key ){
+		// accepts nested keys like 'user.address.street'
+		resetExcept( key );
+	}
+
+	function setDataToNonDefaultValues() {
+		data.user.name.first = createUUID().left(10);
+		data.user.name.last = createUUID().left(12);
+		data.user.email = createUUID().left(8) & "@ortus.local";
+		data.user.address.street = createUUID().left(5) & " Main St";
+		data.user.address.city = createUUID().left(10);
+		data.user.address.state = "VA";
+		data.user.address.zip = randRange(10000,99999);
+		data.user.subscriptions.newsletter = false;
+		data.user.subscriptions.alerts = true;
+		data.user.roles = [ "admin", "auditor" ];
+	}
+
 	function submit() {
 		data.showSuccess = true;
     }
-
 
 }

--- a/test-harness/wires/workshop/NestedDataKeys.cfm
+++ b/test-harness/wires/workshop/NestedDataKeys.cfm
@@ -119,7 +119,7 @@
 					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( ['user.name.last'] )">resetExceptDataKey( ['user.name.last'] )</button>
 					<!--- rest reset array --->
 					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( 'user.name.first' )">resetExceptDataKey( 'user.roles' )</button>
-					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( ['user.name.last'] )">resetExceptDataKey( ['user.roles'] )</button>
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( ['user.roles'] )">resetExceptDataKey( ['user.roles'] )</button>
 					<!--- rest reset booleans --->
 					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( 'user.subscriptions.newsletter' )">resetExceptDataKey( 'user.subscriptions.newsletter' )</button>
 					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( ['user.subscriptions.alerts'] )">resetExceptDataKey( ['user.subscriptions.alerts'] )</button>

--- a/test-harness/wires/workshop/NestedDataKeys.cfm
+++ b/test-harness/wires/workshop/NestedDataKeys.cfm
@@ -6,35 +6,37 @@
 			<div class="alert alert-success" role="alert">
 				<h3>Form submitted successfully!</h3>
 				<strong>Data Submitted:</strong><br>
-				First Name: #user.name.first#<br>
-				Last Name: #user.name.last#<br>
-				Email: #user.email#<br>
-				Address: #user.address.street#<br>
-				City: #user.address.city#<br>
-				State: #user.address.state#<br>
-				Zip: #user.address.zip#<br>
-				Roles: #ArrayToList(user.roles)#<br>
+				user.name.first: #user.name.first#<br>
+				user.name.last: #user.name.last#<br>
+				user.email: #user.email#<br>
+				user.address.street: #user.address.street#<br>
+				user.address.city: #user.address.city#<br>
+				user.address.state: #user.address.state#<br>
+				user.address.zip: #user.address.zip#<br>
+				user.roles: #ArrayToList(user.roles)#<br>
+				user.subscriptions.newsletter: #user.subscriptions.newsletter#<br>
+				user.subscriptions.alerts: #user.subscriptions.alerts#<br>
 			</div>
 		</cfif>
 
-		<form class="row g-3" wire:submit.prevent="submit" >
+		<form class="row g-3" wire:submit.prevent="submit" style="margin-bottom: 20px;" >
 
 			<h3 class="border-bottom">User Info</h3>
 
 			<div class="col-md-6">
 				<label class="form-label">First Name</label>
-				<input type="text" class="form-control" wire:model="user.name.first">
+				<input type="text" class="form-control" wire:model.debounce.500ms="user.name.first">
 			</div>
 
 			<div class="col-md-6">
 				<label class="form-label">Last Name</label>
-				<input type="text" class="form-control" wire:model="user.name.last">
+				<input type="text" class="form-control" wire:model.debounce.500ms="user.name.last">
 			</div>
 
 
 			<div class="col-md-6">
 				<label class="form-label">Email</label>
-				<input type="email" class="form-control"  wire:model="user.email">
+				<input type="email" class="form-control"  wire:model.debounce.500ms="user.email">
 			</div>
 
 			<div class="col-12">
@@ -78,10 +80,93 @@
 
 			</div>
 
+			<h3 class="border-bottom">User Subscriptions</h3>
+
+			<div class="col-md-12">
+
+				<div class="form-check form-check-inline">
+					<input class="form-check-input" type="checkbox" id="inlineCheckbox20" wire:model="user.subscriptions.newsletter">
+					<label class="form-check-label" for="inlineCheckbox20">Newsletters</label>
+				</div>
+
+				<div class="form-check form-check-inline">
+					<input class="form-check-input" type="checkbox" id="inlineCheckbox21" wire:model="user.subscriptions.alerts">
+					<label class="form-check-label" for="inlineCheckbox21">Alerts</label>
+				</div>
+
+			</div>
+
 			<div class="col-12">
 				<button type="submit" class="btn btn-primary">Save</button>
 			</div>
 
+			<h3 class="border-bottom" style="margin-top: 30px;">Test Wire Client Functions</h3>
+
+			<div class="col-12" id="wireWatchOutput" style="max-height: 100px; overflow: auto; font-size: 12px; border: 1px solid ##ccc; padding: 5px; margin-bottom: 10px;">
+				<div><strong>$watch output when changing 'user.name.first'</strong></div>
+			</div>
+
+			<div class="col-6">
+				<div class="d-grid gap-2">
+					<button type="button" class="btn btn-primary" wire:click="setDataToNonDefaultValues()">Set Non Default Values</button>
+					<button type="button" class="btn btn-primary" wire:click="resetDataAll()">resetDataAll()</button>
+					<button type="button" class="btn btn-primary" wire:click="resetDataKey( 'user.name.first' )">resetDataKey( 'user.name.first' )</button>
+					<button type="button" class="btn btn-primary" wire:click="resetDataKey( 'user.name.first,user.name.last' )">resetDataKey( 'user.name.first,user.name.last' )</button>
+					<button type="button" class="btn btn-primary" wire:click="resetDataKey( ['user.name.first'] )">resetDataKey( ['user.name.first'] )</button>
+					<button type="button" class="btn btn-primary" wire:click="resetDataKey( ['user.name.first','user.name.last'] )">resetDataKey( ['user.name.first','user.name.last'] )</button>
+					<!--- rest except testing --->
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( 'user.name.first' )">resetExceptDataKey( 'user.name.first' )</button>
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( ['user.name.last'] )">resetExceptDataKey( ['user.name.last'] )</button>
+					<!--- rest reset array --->
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( 'user.name.first' )">resetExceptDataKey( 'user.roles' )</button>
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( ['user.name.last'] )">resetExceptDataKey( ['user.roles'] )</button>
+					<!--- rest reset booleans --->
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( 'user.subscriptions.newsletter' )">resetExceptDataKey( 'user.subscriptions.newsletter' )</button>
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( ['user.subscriptions.alerts'] )">resetExceptDataKey( ['user.subscriptions.alerts'] )</button>
+					<!--- rest reset multiple keys --->
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( 'user.name.first,user.name.last' )">resetExceptDataKey( 'user.name.first,user.name.last' )</button>
+					<button type="button" class="btn btn-primary" wire:click="resetExceptDataKey( ['user.name.first','user.name.last'] )">resetExceptDataKey( ['user.name.first','user.name.last'] )</button>
+				</div>
+			</div>
+
+			<div class="col-6">
+				<div class="d-grid gap-2">
+					<button type="button" class="btn btn-primary" wire:click="$refresh">$refresh</button>
+					<button type="button" class="btn btn-primary" onclick="testGet( 'user.email' )">$get( 'user.email' )</button>
+					<button type="button" class="btn btn-primary" onclick="testSet( 'user.email', 'me@my.tld' )">$set( 'user.email', 'me@my.tld' )</button>
+					<button type="button" class="btn btn-primary" onclick="testToggle( 'user.subscriptions.alerts' )">$Toggle : user.subscriptions.alerts</button>
+					<button type="button" class="btn btn-primary" onclick="testToggle( 'user.subscriptions.newsletter' )">$Toggle : user.subscriptions.newsletter</button>
+				</div>
+			</div>
+
 		</form>
+		<script>
+			document.addEventListener('livewire:init', () => {
+				Livewire.hook('component.init', ({ component, cleanup }) => {
+					if( component.id === '#_getID()#' ){
+						window.__NestedDataKeys = component.$wire;
+						// test $watch with nested data key
+						window.__NestedDataKeys.$watch('user.name.first', ( value, old ) => {
+							const container = document.getElementById( 'wireWatchOutput' );
+							const newElement = document.createElement('div');
+							newElement.innerHTML = "user.name.first changed => New Value: " + value + ", Old Value: " + old;
+							container.appendChild( newElement );
+							container.scrollTop = container.scrollHeight;
+						})
+					}
+				});
+			});
+			// test clientside wire functions with nested data keys helper functions
+			function testSet( key, value ){
+				window.__NestedDataKeys.$set( key, value );
+			}
+			function testGet( key ){
+				const keyValue = window.__NestedDataKeys.$get( 'user.email' );
+				alert( 'user.email : ' + keyValue );
+			}
+			function testToggle( key ){
+				window.__NestedDataKeys.$toggle( key );
+			}
+		</script>
     </div>
 </cfoutput>


### PR DESCRIPTION
## Interceptors

Creates five interception points for CBWIRE:

1.  **onCBWIREMount**
    - Fired after the initial page render onMount. Will fire even if the wire does not include an onMount() function. Fires only on the initial page render, not on subsequent wire updates.
2.  **preCBWIRERender**
    - Fired before rendering of the wires view
3.  **onCBWIRERender**
    - Fired after rendering of the wires view and includes the rendered HTML of the wire
4.  **preCBWIREUpdate**
    - Fired on all wire updates from the client and before the wire is hydrated and processed
5.  **onCBWIREUpdate**
    - Fired on all wire updates from the client and after CSRFToken verification and processing of all the components. Includes the response rendered response payload to be sent to the client.

Added a test-harness server interceptor that intercepts all cbwire interceptor events and does two things:

1.  log.debug( "{{InterceptorEvent}} called in TestHarnessInterceptor FIRED" );
2.  appends data to an application scope variable used for testing and verification, `application.cbwire_interceptors_run[ "{{InterceptorEvent}}" ]`

The `application.cbwire_interceptors_run` is used in the TestBox tests to verify the interceptors where running.

Added two tests `describe("Event Interceptors" ... )`:

- `it( "should fire the onCBWIREMount, preCBWIRERender, and onCBWIRERender when mounting a wire" ... )`
- `it( "should fire the preCBWIRERender, onCBWIRERender, preCBWIREUpdate and onCBWIREUpdate during a wire update incoming request" ... )`

## Other Misc Updates

### test-harness directory server .json files

Updated web.aliases:

From: `"/modules/cbwire":"../"`

To:  "`/modules/cbwire":"../", "/moduleroot/cbwire":"../"`

Due to the nature of the test-harness configuration, specifically that it loads the module being tested in the `afterAspectsLoad()` of the coldbox config.cfc.

*Another coldbox config.cfc note:*

The config.cfc was loading the cbwire interceptor because coldbox is configured to load the module being tested in the `afterAspectsLoad()` and the cbwire interceptor was not being registered properly.

I removed the cbwire interceptor, and added `controller.getWirebox().getInstance( "coldbox:interceptorService" ).rescanInterceptors();` to the `afterAspectsLoad()` to rescan for module interceptors after it loads the module being tested (cbwire). (It seems this more closely mimics a live environment by loading the interceptor from the module, not in the coldbox config.cfc)

### Component.cfc changes to fix dot notation data keys for client magic functions and reset functions. 

1.  updated `reset()` and `resetExcept()` functions to handle dot notation data keys, i.e. "user.name.first"
2.  Added `_getDotNotationKeys()` function that recursively retrieves all keys from a struct in dot notation and returns them in an array. Used to assist the reset functions.

TestBox ran for:

- [x] Lucee 5
- [x] Lucee 6
- [x] BoxLang
- [x] ACF 2021
- [x] ACF 2023
- [x] ACF 2025