### PR TITLE
Fix for upload test error

### DIFF
--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -1007,7 +1007,7 @@ component output="true" accessors="true" {
         if ( structKeyExists( this, "onUploadError" ) ) {
             invoke( this, "onUploadError", {
                 property: arguments.prop,
-                errors: arguments.errors,
+                errors: isNull( arguments.errors ) ? javaCast( "null", "" ) : arguments.errors,
                 multiple: arguments.multiple
             } );
         }

--- a/test-harness/wires/test/should_call_onuploaderror.cfm
+++ b/test-harness/wires/test/should_call_onuploaderror.cfm
@@ -6,7 +6,7 @@
         "errorInfo": "",
         "isMultiple": false
     };
-    
+
     function onUploadError( property, errors, multiple ) {
         data.uploadErrored = true;
         data.erroredPropertyName = arguments.property;
@@ -21,6 +21,6 @@
         <div>Upload Errored: #uploadErrored#</div>
         <div>Errored Property Name: #erroredPropertyName#</div>
         <div>Error Info: #errorInfo#</div>
-        <div>Is Multiple: #isMultiple#</div>
+        <div>Is Multiple: #isMultiple ? "true" : "false"#</div>
     </div>
 </cfoutput>


### PR DESCRIPTION
Fixes for upload error handling in Component.cfc and corresponding test case

Better handling of null error argument in Component.cfc's  _uploadErrored() function

Modified test wire to manually output "true" or "false" to support ACF tests where boolean is output as YES or NO instead of true or false. 