### PR TITLE
cbsecurity wirebox fix for component.cfc

### DIFF
--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -94,9 +94,9 @@ component output="true" accessors="true" {
 		/*
 			Inject cbSecurity if installed and active
 		*/
-		if( _wirebox.getInstance( "coldbox:moduleService" ).isModuleActive( 'cbSecurity' ) ){
-			variables._cbSecurity = _wirebox.getInstance("@cbsecurity");
-			variables._cbSecurityEnabled = true
+		if( application.cbcontroller.getWireBox().getInstance( "coldbox:moduleService" ).isModuleActive( 'cbSecurity' ) ){
+			variables._cbSecurity = application.cbcontroller.getWireBox().getInstance("cbsecurity@cbsecurity");
+			variables._cbSecurityEnabled = true;
 		}
 
         /*


### PR DESCRIPTION
I was getting the same error from the workflow was getting on my Ubuntu virtual machine.

It appears there were two problems with current `next` branch

1. It could not find `_wirebox` even though it was in the onDIComplete() so I went back to using `application.cbcontroller.getWireBox()` This may be another issue to look into... I'm not sure since going back  `application.cbcontroller.getWireBox()` fixed it.

2. The shorthand in `getInstance("@cbsecurity")` was not working. I suspect it is because the actual model file is named `CBSecurity.cfc `(uppercase CBS) so I changed to use the full `getInstance("cbsecurity@cbsecurity")`

After these changes all tests on all engines where passing. See screenshot below.

<img width="1966" height="1082" alt="image" src="https://github.com/user-attachments/assets/be5efcc0-c608-45a4-91b3-39b380837a03" />
