### PR TITLE
Allow single-file components if @startWire & @endWire are not found. Fixes #168

### DIFF
--- a/models/SingleFileComponentBuilder.cfc
+++ b/models/SingleFileComponentBuilder.cfc
@@ -50,12 +50,25 @@ component accessors="true" singleton {
         local.startedWire = false;
         local.endedWire = false;
 
+		var isBoxLang = arguments.cfmPath.listToArray(".").last() == "bxm" ? true : false;
+		local.insideScriptTag = false;
+		local.REStartScriptTag = isBoxLang ? "<\s*bx:script\s*>" : "<\s*cfscript\s*>";
+		local.REEndScriptTag = isBoxLang ? "<\s*/\s*bx:script\s*>" : "<\s*/\s*cfscript\s*>";
+
         for ( local.line in local.fileContents.listToArray( chr( 10 ) ) ) {
-            if ( local.line contains "@startWire" ) {
+
+			if ( REFindNoCase( local.REStartScriptTag, local.line ) > 0 ) {
+				local.insideScriptTag = true;
+			}
+			if ( REFindNoCase( local.REEndScriptTag, local.line  ) > 0 ) {
+				local.insideScriptTag = false;
+			}
+
+            if ( local.insideScriptTag && local.line contains "@startWire" ) {
                 local.startedWire = true;
                 continue;
             }
-            if ( local.line contains "@endWire" ) {
+			if ( local.insideScriptTag && local.line contains "@endWire" ) {
                 local.endedWire = true;
                 continue;
             }
@@ -65,10 +78,6 @@ component accessors="true" singleton {
             } else {
                 local.remainingContents &= local.line & chr( 10 );
             }
-        }
-
-        if ( !local.startedWire || !local.endedWire ) {
-            throw( type="CBWIREException", message="The CBWIRE component '#arguments.cfmPath#' is missing '//@startWire' and '//@endWire' markers. Please place these in your CFSCRIPT block and place each one on a single line." );
         }
 
         return {
@@ -84,16 +93,18 @@ component accessors="true" singleton {
      */
     private function generateFiles( componentName, sourcePath ){
 
+		var isBoxLang = arguments.sourcePath.listToArray(".").last() == "bxm" ? true : false;
+
         local.parsedContents = parseContents( arguments.sourcePath );
 
         arguments.componentName = replaceNoCase( arguments.componentName, "wires.", "" );
-        
+
         arguments.componentName = replace( arguments.componentName, ".", "/", "all" );
 
         local.currentDirectory = getDirectoryFromPath( getCurrentTemplatePath() );
         local.tmpDirectory = local.currentDirectory & "tmp";
 
-        if ( arguments.sourcePath contains ".bxm" ) {
+        if ( isBoxLang ) {
             local.tmpClassPath = local.tmpDirectory & "/#arguments.componentName#.bx";
             local.tmpTemplatePath = local.tmpDirectory & "/#arguments.componentName#.bxm";
         } else {
@@ -120,7 +131,7 @@ component accessors="true" singleton {
         local.componentDirectory = getDirectoryFromPath( local.tmpClassPath );
         ensureDirectoryExists( local.componentDirectory );
 
-        if ( arguments.sourcePath contains ".bxm" ) {
+        if ( isBoxLang ) {
             local.emptySingleFileComponent = fileRead( local.currentDirectory & "EmptySingleFileComponent.bx" );
         } else {
             local.emptySingleFileComponent = fileRead( local.currentDirectory & "EmptySingleFileComponent.cfc" );
@@ -175,7 +186,7 @@ component accessors="true" singleton {
         }
 
         local.parentDirectory = getDirectoryFromPath( arguments.directoryPath.reReplace( "[\\/]$", "" ) );
-        
+
         if ( len( local.parentDirectory ) && local.parentDirectory != arguments.directoryPath ) {
             ensureDirectoryExists( local.parentDirectory );
         }

--- a/models/SingleFileComponentBuilder.cfc
+++ b/models/SingleFileComponentBuilder.cfc
@@ -50,10 +50,10 @@ component accessors="true" singleton {
         local.startedWire = false;
         local.endedWire = false;
 
-		var isBoxLang = arguments.cfmPath.listToArray(".").last() == "bxm" ? true : false;
+		local.isBoxLang = arguments.cfmPath.listToArray(".").last() == "bxm" ? true : false;
 		local.insideScriptTag = false;
-		local.REStartScriptTag = isBoxLang ? "<\s*bx:script\s*>" : "<\s*cfscript\s*>";
-		local.REEndScriptTag = isBoxLang ? "<\s*/\s*bx:script\s*>" : "<\s*/\s*cfscript\s*>";
+		local.REStartScriptTag = local.isBoxLang ? "<\s*bx:script\s*>" : "<\s*cfscript\s*>";
+		local.REEndScriptTag = local.isBoxLang ? "<\s*/\s*bx:script\s*>" : "<\s*/\s*cfscript\s*>";
 
         for ( local.line in local.fileContents.listToArray( chr( 10 ) ) ) {
 
@@ -93,7 +93,7 @@ component accessors="true" singleton {
      */
     private function generateFiles( componentName, sourcePath ){
 
-		var isBoxLang = arguments.sourcePath.listToArray(".").last() == "bxm" ? true : false;
+		local.isBoxLang = arguments.sourcePath.listToArray(".").last() == "bxm" ? true : false;
 
         local.parsedContents = parseContents( arguments.sourcePath );
 
@@ -104,7 +104,7 @@ component accessors="true" singleton {
         local.currentDirectory = getDirectoryFromPath( getCurrentTemplatePath() );
         local.tmpDirectory = local.currentDirectory & "tmp";
 
-        if ( isBoxLang ) {
+        if ( local.isBoxLang ) {
             local.tmpClassPath = local.tmpDirectory & "/#arguments.componentName#.bx";
             local.tmpTemplatePath = local.tmpDirectory & "/#arguments.componentName#.bxm";
         } else {
@@ -131,7 +131,7 @@ component accessors="true" singleton {
         local.componentDirectory = getDirectoryFromPath( local.tmpClassPath );
         ensureDirectoryExists( local.componentDirectory );
 
-        if ( isBoxLang ) {
+        if ( local.isBoxLang ) {
             local.emptySingleFileComponent = fileRead( local.currentDirectory & "EmptySingleFileComponent.bx" );
         } else {
             local.emptySingleFileComponent = fileRead( local.currentDirectory & "EmptySingleFileComponent.cfc" );

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -158,11 +158,17 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 expect( result ).toInclude( "<h1>A Single File Boxlang Component</h1>" );
             }, skip=!isBoxLang() );
 
-            it( "should raise error if markers are not found in single-file component", function() {
-                expect( function() {
-                    var result = CBWIREController.wire( "test.should_raise_error_for_single_file_component" );
-                } ).toThrow( type="CBWIREException" );
+            it( title="should allow single-file components if @startWire & @endWire are not found", body=function() {
+				var result = CBWIREController.wire( "test.should_alllow_without_markers_for_single_file_component" );
+                expect( result ).toInclude( "<p>SUCCESS!</p>" );
+                expect( result ).toInclude( "<p>Hello, CBWIRE!</p>" );
             } );
+
+            it( title="should allow a boxlang single-file components if @startWire & @endWire are not found", body=function() {
+				var result = CBWIREController.wire( "test.should_alllow_without_markers_for_single_file_boxlang_component" );
+                expect( result ).toInclude( "<p>SUCCESS!</p>" );
+                expect( result ).toInclude( "<p>Hello, CBWIRE!</p>" );
+            }, skip=!isBoxLang() );
 
             it("should have generated setters available in onMount", function() {
                 var result = CBWIREController.wire( "test.should_have_generated_setters_and_getters_available_in_onmount" );

--- a/test-harness/wires/test/should_alllow_without_markers_for_single_file_boxlang_component.bxm
+++ b/test-harness/wires/test/should_alllow_without_markers_for_single_file_boxlang_component.bxm
@@ -1,0 +1,18 @@
+<bx:script>
+
+</bx:script>
+
+<bx:output>
+	<bx:script>
+		someString="Hello, CBWIRE!";
+
+	</bx:script>
+    <div>
+
+		<h1>Test Without @startWire &amp; @endWire</h1>
+        <p>SUCCESS!</p>
+		<p>#someString#</p>
+
+
+    </div>
+</bx:output>

--- a/test-harness/wires/test/should_alllow_without_markers_for_single_file_component.cfm
+++ b/test-harness/wires/test/should_alllow_without_markers_for_single_file_component.cfm
@@ -1,0 +1,18 @@
+<cfscript>
+
+</cfscript>
+
+<cfoutput>
+	<cfscript>
+		someString="Hello, CBWIRE!";
+
+	</cfscript>
+    <div>
+
+		<h1>Test Without @startWire &amp; @endWire</h1>
+        <p>SUCCESS!</p>
+		<p>#someString#</p>
+
+
+    </div>
+</cfoutput>


### PR DESCRIPTION
Adds the ability to create a single-file wire without the @ wire markers while continuing to allow use of script tags in the wire template. 

Successfully ran tests on all supported engines with all passing!

**Updated `models/SingleFileComponentBuilder.cfc `**
- Tracks if inside script tag while parsing sing-file wire contents
- Only searches for @ markers while inside script tags
- Removed throwing of exception if @ markers are not found
- Passes through the initial empty string for component content so you end up with a basic component with the onRender function
- changed boxlang detection method and track in a variable to prevent multiple checks in modified functions where needed.

**Updated `test-harness/tests/specs/CBWIRESpec.cfc`**
- removed test for throwing exception
- Added test for single-file component without @ markers for CF
- Added test for single-file component without @ markers for BoxLang
- Tests include multiple script tags, one blank and one used to set variable inside wire component.

**Added test wire components:**
- `test-harness/wires/test/should_alllow_without_markers_for_single_file_boxlang_component.bxm`
- `test-harness/wires/test/should_alllow_without_markers_for_single_file_component.cfm`