### PR TITLE
Update js() function in Component.cfc to accept params paramater

### DIFF
--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -523,11 +523,14 @@ component output="true" accessors="true" {
     /**
      * Provide ability to return and execute Javascript
      * in the browser.
+	 *
+	 * @expression string | The javascript expression to execute.
+	 * @params array | (Optional) An array of parameters. Currently a placeholder for compatibility
      *
      * @return void
      */
-    function js( code ) {
-        variables._xjs.append( arguments.code );
+    function js( expression, params=[] ) {
+        variables._xjs.append( { "expression" : expression, "params" : params } );
     }
 
     /**


### PR DESCRIPTION
Livewire.js changed the handling of the xjs being sent in the payload for the wire to an array of structs with params options. It was throwing a `Cannot convert undefined or null to object` javascript error in the browser for any javascript added with the `js()` function.

Changed the parameter names to match what livewire.js is using and the params defaults to an empty array providing backwards compatibility.

