### PR TITLE
Fix tests and whitespace in server json files

### DIFF
--- a/test-harness/server-adobe@2023.json
+++ b/test-harness/server-adobe@2023.json
@@ -5,7 +5,7 @@
         "cfengine":"adobe@2023"
     },
     "web":{
-        "caseSensitivePaths": false,
+        "caseSensitivePaths":false,
         "http":{
             "port":"60299"
         },

--- a/test-harness/server-adobe@2025.json
+++ b/test-harness/server-adobe@2025.json
@@ -5,7 +5,7 @@
         "cfengine":"adobe@2025"
     },
     "web":{
-        "caseSensitivePaths": false,
+        "caseSensitivePaths":false,
         "http":{
             "port":"60299"
         },

--- a/test-harness/server-boxlang-cfml@1.json
+++ b/test-harness/server-boxlang-cfml@1.json
@@ -5,7 +5,7 @@
         "cfengine":"boxlang@be"
     },
     "web":{
-        "caseSensitivePaths": false,
+        "caseSensitivePaths":false,
         "http":{
             "port":"60299"
         },

--- a/test-harness/server-lucee@5.json
+++ b/test-harness/server-lucee@5.json
@@ -5,7 +5,7 @@
         "cfengine":"lucee@5"
     },
     "web":{
-        "caseSensitivePaths": false,
+        "caseSensitivePaths":false,
         "http":{
             "port":"60299"
         },

--- a/test-harness/server-lucee@6.json
+++ b/test-harness/server-lucee@6.json
@@ -5,7 +5,7 @@
         "cfengine":"lucee@6"
     },
     "web":{
-        "caseSensitivePaths": false,
+        "caseSensitivePaths":false,
         "http":{
             "port":"60299"
         },

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -1182,7 +1182,11 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 );
                 var response = cbwireController.handleRequest( payload, event );
                 expect( response.components[1].effects.xjs ).toBeArray();
-                expect( response.components[1].effects.xjs.first() ).toBe( "alert('Hello from CBWIRE!');" );
+				var firstXJS = response.components[1].effects.xjs.first();
+				expect( firstXJS ).toBeStruct();
+                expect( firstXJS ).toHaveKey( "expression" );
+                expect( firstXJS ).toHaveKey( "params" );
+                expect( firstXJS.expression ).toBe( "alert('Hello from CBWIRE!');" );
             } );
 
             it( "should track return values", () => {


### PR DESCRIPTION
Updated tests to verify js() is appending a struct, that the struct keys are correct and that the javascript is as expected

Updated server json files with the whitespace removed that command box automatically removes so that git will not continue to see all the server json files as modified when running the test harness tests.