### PR TITLE
fix for two file wire from within a module

### DIFF
--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -81,6 +81,7 @@ component output="true" accessors="true" {
         variables._redirect = "";
         variables._redirectUsingNavigate = false;
         variables._isolate = false;
+		variables._path = "";
         variables._renderedContent = "";
         variables._scripts = [:];
         variables._assets = [:];

--- a/models/Component.cfc
+++ b/models/Component.cfc
@@ -229,7 +229,7 @@ component output="true" accessors="true" {
      */
     function template( viewPath, params = {} ) {
         // Normalize the view path
-        local.normalizedPath = variables._renderService.normalizeViewPath( arguments.viewPath );
+        local.normalizedPath = variables._renderService.normalizeViewPath( arguments.viewPath, variables._path );
         // Render the view content and trim the result
         return variables._renderService.renderViewContent( this, local.normalizedPath, arguments.params );
     }
@@ -360,7 +360,7 @@ component output="true" accessors="true" {
         // Determine if component should be lazy loaded
         // If lazy parameter is explicitly provided, use that value
         // Otherwise, use the component's lazy preference
-        local.shouldLazyLoad = isNull( arguments.lazy ) ? 
+        local.shouldLazyLoad = isNull( arguments.lazy ) ?
             local.instance._getLazyLoad() :  // Use component's preference if no explicit parameter
             arguments.lazy;  // Use explicit parameter value
 

--- a/models/services/RenderService.cfc
+++ b/models/services/RenderService.cfc
@@ -168,6 +168,7 @@ component accessors="true" singleton {
      * to a slash notation path, check for the existence of .bxm or .cfm files, and ensure the path is correctly formatted.
      *
      * @viewPath string | The dot notation path to the view template to be rendered, without the .cfm extension.
+	 * @componentPath string | The component path, used to determine if the normalized path should be prefixed with "wires/".
      *
      * @return string
      */
@@ -190,7 +191,7 @@ component accessors="true" singleton {
             throw( type="CBWIREException", message="A .bxm or .cfm template could not be found for '#arguments.viewPath#'." );
         }
 
-        if ( !find( "@", arguments.componentPath ) && left( paths.normalizedPath, 6 ) != "wires/" ) {
+        if ( !isNull( arguments.componentPath ) && !find( "@", arguments.componentPath ) && left( paths.normalizedPath, 6 ) != "wires/" ) {
             paths.normalizedPath = "wires/" & paths.normalizedPath;
         }
         if ( left( paths.normalizedPath, 1 ) != "/" ) {

--- a/models/services/RenderService.cfc
+++ b/models/services/RenderService.cfc
@@ -67,7 +67,7 @@ component accessors="true" singleton {
 
             wire.set_renderedContent( local.viewContent );
             return local.viewContent;
-        }       
+        }
 
         return wire.get_renderedContent();
     }
@@ -164,14 +164,14 @@ component accessors="true" singleton {
     }
 
     /**
-     * Normalizes the view path for rendering. This means it will convert the dot notation path 
+     * Normalizes the view path for rendering. This means it will convert the dot notation path
      * to a slash notation path, check for the existence of .bxm or .cfm files, and ensure the path is correctly formatted.
      *
      * @viewPath string | The dot notation path to the view template to be rendered, without the .cfm extension.
      *
      * @return string
      */
-    function normalizeViewPath( required viewPath ) {
+    function normalizeViewPath( required viewPath, required componentPath ) {
         var paths = buildViewPaths( arguments.viewPath );
 
         if ( paths.normalizedPath contains "cbwire/models/tmp/" ) {
@@ -190,7 +190,7 @@ component accessors="true" singleton {
             throw( type="CBWIREException", message="A .bxm or .cfm template could not be found for '#arguments.viewPath#'." );
         }
 
-        if ( left( paths.normalizedPath, 6 ) != "wires/" ) {
+        if ( !find( "@", arguments.componentPath ) && left( paths.normalizedPath, 6 ) != "wires/" ) {
             paths.normalizedPath = "wires/" & paths.normalizedPath;
         }
         if ( left( paths.normalizedPath, 1 ) != "/" ) {

--- a/test-harness/modules_app/testingmodule/wires/twoFileModuleComponent.cfc
+++ b/test-harness/modules_app/testingmodule/wires/twoFileModuleComponent.cfc
@@ -1,0 +1,8 @@
+component extends="cbwire.models.Component" {
+
+
+	data = {
+		"myDataPropKey" : "My Data Prop Value"
+	};
+
+}

--- a/test-harness/modules_app/testingmodule/wires/twoFileModuleComponent.cfm
+++ b/test-harness/modules_app/testingmodule/wires/twoFileModuleComponent.cfm
@@ -1,6 +1,6 @@
 <cfoutput>
     <div>
-        <cfif datePart( 'h', now() ) lt 12 >
+        <cfif datePart( "h", now() ) lt 12 >
             <p>Good Morning and hello CBWire Developer from a two file wire in a module!</p>
         <cfelse>
             <p>Good Afternoon and hello CBWire Developer from a two file wire in a module!</p>

--- a/test-harness/modules_app/testingmodule/wires/twoFileModuleComponent.cfm
+++ b/test-harness/modules_app/testingmodule/wires/twoFileModuleComponent.cfm
@@ -1,0 +1,9 @@
+<cfoutput>
+    <div>
+        <cfif datePart( 'h', now() ) lt 12 >
+            <p>Good Morning and hello CBWire Developer from a two file wire in a module!</p>
+        <cfelse>
+            <p>Good Afternoon and hello CBWire Developer from a two file wire in a module!</p>
+        </cfif>
+    </div>
+</cfoutput>

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -727,7 +727,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 var settings = getInstance( "coldbox:modulesettings:cbwire" );
                 var originalSetting = settings.csrfEnabled;
                 settings.csrfEnabled = false;
-                
+
                 var payload = incomingRequest(
                     memo = {
                         "name": "TestComponent",
@@ -747,12 +747,12 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     updates = {},
                     csrfToken = "badToken"
                 );
-                
+
                 // Should not throw an error even with bad token when CSRF is disabled
                 var response = cbwireController.handleRequest( payload, event );
                 expect( isStruct( response ) ).toBeTrue();
                 expect( response.components[1].effects.html ).toInclude( "CBWIRE Slays!" );
-                
+
                 // Restore original setting
                 settings.csrfEnabled = originalSetting;
             } );
@@ -761,10 +761,10 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 var settings = getInstance( "coldbox:modulesettings:cbwire" );
                 var originalSetting = settings.csrfEnabled;
                 settings.csrfEnabled = false;
-                
+
                 var token = cbwireController.generateCSRFToken();
                 expect( token ).toBe( "" );
-                
+
                 // Restore original setting
                 settings.csrfEnabled = originalSetting;
             } );
@@ -1819,9 +1819,14 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} ).toThrow( type="ModuleNotFound" );
 			} );
 
-			it( "should render component from module using default wires location", function() {
+			it( "should render single file component from module using default wires location", function() {
 				var result = cbwireController.wire( "NestedModuleDefaultComponent@testingmodule" );
 				expect( result ).toContain( "Nested module component using default wires location" );
+			} );
+
+			it( "should render a two file component from module using default wires location", function() {
+				var result = cbwireController.wire( "twoFileModuleComponent@testingmodule" );
+				expect( result ).toContain( "hello CBWire Developer from a two file wire in a module" );
 			} );
 
 			it( "should render component from module using nested folder", function() {

--- a/test-harness/tests/specs/unit/services/RenderServiceSpec.cfc
+++ b/test-harness/tests/specs/unit/services/RenderServiceSpec.cfc
@@ -291,7 +291,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     expect( result ).toBe( expectedPath );
                 });
 
-                it( "should return .cfm module path when wire is located in module wires direcotry", function() {
+                it( "should return .cfm module path when wire is located in module wires directory", function() {
                     var input = "modules_app.testingModule.wires.twoFileModuleComponent";
 					// simulate the components variables._path which is what is passed to the wire() method
 					var component_path = "twoFileModuleComponent@testingModule";

--- a/test-harness/tests/specs/unit/services/RenderServiceSpec.cfc
+++ b/test-harness/tests/specs/unit/services/RenderServiceSpec.cfc
@@ -1,13 +1,13 @@
 component extends="coldbox.system.testing.BaseTestCase" {
 
-    
+
     function beforeAll() {
         variables.mockController = createStub();
         variables.mockUtility = createStub();
         variables.mockChecksumService = createStub();
         variables.mockValidationService = createStub();
         variables.mockRequestService = createStub();
-        
+
         variables.renderService = prepareMock( new cbwire.models.services.RenderService() );
         renderService.setCBWIREController( mockController );
         renderService.setUtilityService( mockUtility );
@@ -263,6 +263,8 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
                 it( "should return .bxm path when .bxm file exists", function() {
                     var input = "my.view.template";
+					// simulate the components variables._path which is what is passed to the wire() method
+					var component_path = "my.view.template";
                     var bxmAbsolutePath = expandPath( "/my/view/template.bxm" );
                     var cfmAbsolutePath = expandPath( "/my/view/template.cfm" );
                     var expectedPath = "/wires/my/view/template.bxm";
@@ -270,12 +272,14 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     mockUtility.$( "fileExists" ).$args( bxmAbsolutePath ).$results( true );
                     mockUtility.$( "fileExists" ).$args( cfmAbsolutePath ).$results( false );
 
-                    var result = renderService.normalizeViewPath( input );
+                    var result = renderService.normalizeViewPath( input, component_path );
                     expect( result ).toBe( expectedPath );
                 });
 
                 it( "should return .cfm path when only .cfm file exists", function() {
                     var input = "my.view.template";
+					// simulate the components variables._path which is what is passed to the wire() method
+					var component_path = "my.view.template";
                     var bxmAbsolutePath = expandPath( "/my/view/template.bxm" );
                     var cfmAbsolutePath = expandPath( "/my/view/template.cfm" );
                     var expectedPath = "/wires/my/view/template.cfm";
@@ -283,12 +287,31 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     mockUtility.$( "fileExists" ).$args( bxmAbsolutePath ).$results( false );
                     mockUtility.$( "fileExists" ).$args( cfmAbsolutePath ).$results( true );
 
-                    var result = renderService.normalizeViewPath( input );
+                    var result = renderService.normalizeViewPath( input, component_path );
+                    expect( result ).toBe( expectedPath );
+                });
+
+                it( "should return .cfm module path when wire is located in module wires direcotry", function() {
+                    var input = "modules_app.testingModule.wires.twoFileModuleComponent";
+					// simulate the components variables._path which is what is passed to the wire() method
+					var component_path = "twoFileModuleComponent@testingModule";
+					// use full path to module wire
+                    var bxmAbsolutePath = expandPath( "../modules_app/testingModule/wires/twoFileModuleComponent.bxm" );
+                    var cfmAbsolutePath = expandPath( "../modules_app/testingModule/wires/twoFileModuleComponent.cfm" );
+
+                    var expectedPath = "/modules_app/testingModule/wires/twoFileModuleComponent.cfm";
+					// mock the file exists calls for both .bxm and .cfm paths
+                    mockUtility.$( "fileExists" ).$args( bxmAbsolutePath ).$results( false );
+                    mockUtility.$( "fileExists" ).$args( cfmAbsolutePath ).$results( true );
+
+                    var result = renderService.normalizeViewPath( input, component_path );
                     expect( result ).toBe( expectedPath );
                 });
 
                 it( "should throw when neither .bxm nor .cfm exists", function() {
                     var input = "my.view.template";
+					// simulate the components variables._path which is what is passed to the wire() method
+					var component_path = "my.view.template";
                     var bxmAbsolutePath = expandPath( "/nonexistent/view.bxm" );
                     var cfmAbsolutePath = expandPath( "/nonexistent/view.cfm" );
                     var expectedPath = "/wires/my/view/template.cfm";
@@ -297,29 +320,34 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     mockUtility.$( "fileExists" ).$args( cfmAbsolutePath ).$results( false );
 
                     expect( function() {
-                        renderService.normalizeViewPath( "nonexistent.view" );
+                        renderService.normalizeViewPath( "nonexistent.view", component_path );
                     }).toThrow( "CBWIREException" );
                 });
 
                 it( "should return path with .bxm for tmp path when .bxm exists", function() {
                     var input = "cbwire.models.tmp.componentName";
+					// simulate the components variables._path which is what is passed to the wire() method
+					var component_path = "cbwire.models.tmp.componentName";
 
                     mockUtility.$( "fileExists" ).$args( expandPath( "/cbwire/models/tmp/componentName.bxm" ) ).$results( true );
                     mockUtility.$( "fileExists" ).$args( expandPath( "/cbwire/models/tmp/componentName.cfm" ) ).$results( false );
 
-                    var result = renderService.normalizeViewPath( input );
+                    var result = renderService.normalizeViewPath( input, component_path );
                     expect( result ).toBe( "/cbwire/models/tmp/componentName.bxm" );
                 });
 
                 it( "should return path with .cfm for tmp path when .cfm exists", function() {
                     var input = "cbwire.models.tmp.componentName";
+					// simulate the components variables._path which is what is passed to the wire() method
+					var component_path = "cbwire.models.tmp.componentName";
 
                     mockUtility.$( "fileExists" ).$args( expandPath( "/cbwire/models/tmp/componentName.bxm" ) ).$results( false );
                     mockUtility.$( "fileExists" ).$args( expandPath( "/cbwire/models/tmp/componentName.cfm" ) ).$results( true );
 
-                    var result = renderService.normalizeViewPath( input );
+                    var result = renderService.normalizeViewPath( input, component_path );
                     expect( result ).toBe( "/cbwire/models/tmp/componentName.cfm" );
                 });
+
             });
 
             describe( "getTemplatePath()", function() {

--- a/test-harness/tests/specs/unit/services/RenderServiceSpec.cfc
+++ b/test-harness/tests/specs/unit/services/RenderServiceSpec.cfc
@@ -264,7 +264,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 it( "should return .bxm path when .bxm file exists", function() {
                     var input = "my.view.template";
 					// simulate the components variables._path which is what is passed to the wire() method
-					var component_path = "my.view.template";
+					var componentPath = "my.view.template";
                     var bxmAbsolutePath = expandPath( "/my/view/template.bxm" );
                     var cfmAbsolutePath = expandPath( "/my/view/template.cfm" );
                     var expectedPath = "/wires/my/view/template.bxm";
@@ -272,7 +272,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     mockUtility.$( "fileExists" ).$args( bxmAbsolutePath ).$results( true );
                     mockUtility.$( "fileExists" ).$args( cfmAbsolutePath ).$results( false );
 
-                    var result = renderService.normalizeViewPath( input, component_path );
+                    var result = renderService.normalizeViewPath( input, componentPath );
                     expect( result ).toBe( expectedPath );
                 });
 
@@ -292,14 +292,14 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 });
 
                 it( "should return .cfm module path when wire is located in module wires directory", function() {
-                    var input = "modules_app.testingModule.wires.twoFileModuleComponent";
+                    var input = "modules_app.testingmodule.wires.twoFileModuleComponent";
 					// simulate the components variables._path which is what is passed to the wire() method
-					var component_path = "twoFileModuleComponent@testingModule";
+					var component_path = "twoFileModuleComponent@testingmodule";
 					// use full path to module wire
-                    var bxmAbsolutePath = expandPath( "../modules_app/testingModule/wires/twoFileModuleComponent.bxm" );
-                    var cfmAbsolutePath = expandPath( "../modules_app/testingModule/wires/twoFileModuleComponent.cfm" );
+                    var bxmAbsolutePath = expandPath( "../modules_app/testingmodule/wires/twoFileModuleComponent.bxm" );
+                    var cfmAbsolutePath = expandPath( "../modules_app/testingmodule/wires/twoFileModuleComponent.cfm" );
 
-                    var expectedPath = "/modules_app/testingModule/wires/twoFileModuleComponent.cfm";
+                    var expectedPath = "/modules_app/testingmodule/wires/twoFileModuleComponent.cfm";
 					// mock the file exists calls for both .bxm and .cfm paths
                     mockUtility.$( "fileExists" ).$args( bxmAbsolutePath ).$results( false );
                     mockUtility.$( "fileExists" ).$args( cfmAbsolutePath ).$results( true );


### PR DESCRIPTION
Reference Issue: https://github.com/coldbox-modules/cbwire/issues/261

CBWire is prepending `wire/` to the view path and not taking into account if the wire is in a module. This only happens for two file wires, not single file wires. 

- [x] Modified `RenderService.cfc` method `normalizeViewPath()` to take a second argument. This argument is the `variables._path` value in `Component.cfc`. This is the wire name passed to the `wire()` method and is used to determine if it contains an @ denoting a module wire. 
- [x] Updated existing  `normalizeViewPath()` tests to account for this second argument
- [x] Added a new test for `normalizeViewPath()` to validate for a two file wire from a module path
- [x] Added a two file wire into the test-harness `testingModule` 
- [x] Added a test to verify rendering of the view for the two wire module in the test-harness `testingModule` 
- [x] Passed all tests for all supported engines in local dev (now lets see if they pass on github)
- [x] and... apparently my vscode removed whitespace in a bunch of places :shrug: