### PR TITLE
CBWire Application Helper : wireGenericView()

### DIFF
--- a/helpers/helpers.cfm
+++ b/helpers/helpers.cfm
@@ -36,4 +36,28 @@
     function wire(required string name, struct params = {}, string key = "", lazy, boolean lazyIsolated = true ) {
         return getInstance("CBWIREController@cbwire").wire( argumentCollection=arguments );
     }
+
+	/**
+	 * A helper function to set up the view arguments and call the generic wire view.
+	 * Eliminates the need to manually create a basic view that would usually only contains a
+	 * title (optional) and the wire() method call with the appropriate arguments.
+	 *
+	 * @wireName string | The name of the wire component to render. Required.
+	 * @wireParams struct | The parameters to pass to the wire component. Optional, defaults to an empty struct.
+	 * @viewArgs struct | Additional arguments to pass to the view. Optional, defaults to an empty struct.
+	 * @viewArgs.title string | An optional title to display above the wire component in the view. { "title" : "My Cool Page Title" }
+	 * @viewArgs.titleTag string | An optional HTML tag to wrap the title in. Defaults to h1 if title is provided without a titleTag. { "titleTag" : "h2" }
+	 *
+	 * @return void | Sets the events view to the generic wire view with the appropriate arguments.
+	 */
+	function wireGenericView( required string wireName, struct wireParams = {}, struct viewArgs={} ) {
+		// init event if not available in the current context and scope it to this method
+		if( isNull( event ) ){
+			var event = wirebox.getInstance( "coldbox:requestContext" );
+		}
+		// append wire name and params to view args so they can be used in the view
+		viewArgs._wireName = wireName;
+		viewArgs._wireParams = wireParams;
+		event.setView( view = "genericWireView", module="cbwire", args = viewArgs );
+	}
 </cfscript>

--- a/test-harness/handlers/Main.cfc
+++ b/test-harness/handlers/Main.cfc
@@ -8,6 +8,32 @@ component {
 		event.setView( "main/index" );
 	}
 
+	any function testGenericWireView1( event, rc, prc ){
+		/*
+			Bypass the need for a view and just call the wireGenericView() helper directly in the handler method
+			this will render the specified component in the generic wire view and pass the title and titleTag
+			arguments to it as well
+		*/
+		wireGenericView(
+			"genericWireViewTesting.genericTest",
+			{},
+			{ title = "CBWIRE Test wireGenericView() Helper One", titleTag = "h2" }
+		);
+	}
+
+	any function testGenericWireView2( event, rc, prc ){
+		/*
+			Bypass the need for a view and just call the wireGenericView() helper directly in the handler method
+			this will render the specified component in the generic wire view and pass the title and titleTag
+			arguments to it as well
+		*/
+		wireGenericView(
+			"genericWireViewTesting.genericTest",
+			{ "testArgument" : "Test Argument Passed In Succesfully" },
+			{ title = "CBWIRE Test wireGenericView() Helper Two", titleTag = "h3" }
+		);
+	}
+
 	// Run on first init
 	any function onAppInit( event, rc, prc ){
 	}

--- a/test-harness/tests/specs/CBWIRESpec.cfc
+++ b/test-harness/tests/specs/CBWIRESpec.cfc
@@ -127,6 +127,45 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 expect( beforeHead ).toInclude( "<link rel=""stylesheet"" href=""https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"">" );
             } );
 
+            it( "should use wireGenericView() to set the event view to view=genericWireView & module=cbwire (without wire params)", function() {
+
+				var event = this.get( "Main.testGenericWireView1" );
+				var prc = event.getPrivateContext();
+				var html = event.getRenderedContent();
+				// validate view and module were set properly by wireGenericView() helper
+				expect( prc.currentView ).toBe( "genericWireView" );
+				expect( prc.viewModule ).toBe( "cbwire" );
+				expect( prc.currentViewArgs._WIRENAME ).toBe( "genericWireViewTesting.genericTest" );
+				// validate custom title tags
+				expect( html ).toInclude( "<h2>" );
+				expect( html ).toInclude( "</h2>" );
+				// validate custom title
+				expect( html ).toInclude( "CBWIRE Test wireGenericView() Helper One" );
+				// validate that the wire component rendered in the view
+				expect( html ).toInclude( "Generic Wire View Test Component" );
+				expect( html ).toInclude( "No Test Argument Passed" );
+           } );
+
+            it( "should use wireGenericView() to set the event view to view=genericWireView & module=cbwire (with wire params)", function() {
+
+				var event = this.get( "Main.testGenericWireView2" );
+				var prc = event.getPrivateContext();
+				var html = event.getRenderedContent();
+				// validate view and module were set properly by wireGenericView() helper
+				expect( prc.currentView ).toBe( "genericWireView" );
+				expect( prc.viewModule ).toBe( "cbwire" );
+				expect( prc.currentViewArgs._WIRENAME ).toBe( "genericWireViewTesting.genericTest" );
+				// validate custom title tags
+				expect( html ).toInclude( "<h3>" );
+				expect( html ).toInclude( "</h3>" );
+				// validate custom title
+				expect( html ).toInclude( "CBWIRE Test wireGenericView() Helper Two" );
+				// validate that the wire component rendered in the view
+				expect( html ).toInclude( "Generic Wire View Test Component" );
+				expect( html ).toInclude( "Test Argument Passed In Succesfully" );
+           } );
+
+
         } );
 
         describe("Component.cfc", function() {
@@ -727,7 +766,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 var settings = getInstance( "coldbox:modulesettings:cbwire" );
                 var originalSetting = settings.csrfEnabled;
                 settings.csrfEnabled = false;
-                
+
                 var payload = incomingRequest(
                     memo = {
                         "name": "TestComponent",
@@ -747,12 +786,12 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     updates = {},
                     csrfToken = "badToken"
                 );
-                
+
                 // Should not throw an error even with bad token when CSRF is disabled
                 var response = cbwireController.handleRequest( payload, event );
                 expect( isStruct( response ) ).toBeTrue();
                 expect( response.components[1].effects.html ).toInclude( "CBWIRE Slays!" );
-                
+
                 // Restore original setting
                 settings.csrfEnabled = originalSetting;
             } );
@@ -761,10 +800,10 @@ component extends="coldbox.system.testing.BaseTestCase" {
                 var settings = getInstance( "coldbox:modulesettings:cbwire" );
                 var originalSetting = settings.csrfEnabled;
                 settings.csrfEnabled = false;
-                
+
                 var token = cbwireController.generateCSRFToken();
                 expect( token ).toBe( "" );
-                
+
                 // Restore original setting
                 settings.csrfEnabled = originalSetting;
             } );

--- a/test-harness/wires/genericWireViewTesting/genericTest.cfm
+++ b/test-harness/wires/genericWireViewTesting/genericTest.cfm
@@ -1,0 +1,22 @@
+<cfscript>
+    //@startWire
+
+    data = {
+        "title": "Generic Wire View Test Component",
+		"testArgument": "No Test Argument Passed"
+    }
+
+    function onMount( event, rc, prc, params ){
+        if( structKeyExists( params, "testArgument" ) ){
+			data.testArgument = params.testArgument;
+		}
+    }
+    //@endWire
+</cfscript>
+
+<cfoutput>
+    <div>
+        Title: #title#<br>
+		Test Argument: #testArgument#
+    </div>
+</cfoutput>

--- a/views/genericWireView.cfm
+++ b/views/genericWireView.cfm
@@ -1,0 +1,15 @@
+<cfoutput>
+	<cfif args.keyExists( "_wireName" ) && len( args._wireName ) >
+		<cfif args.keyExists( "title" ) AND len(  args.title ) >
+			#args.keyExists( "titleTag" ) && len( args.titleTag ) ? "<" & args.titleTag & ">" : "<h1>"#
+			#args.title#
+			#args.keyExists( "titleTag" ) && len( args.titleTag ) ? "</" & args.titleTag & ">" : "</h1>"#
+		</cfif>
+		#wire( name=args._wireName, params=args._wireParams )#
+	<cfelse>
+		<p style="color: black; background-color: ##E6B444;">
+			<span style="font-weight: bold;">No wire component name specified for wireGenericView() method!</span><br>
+			<span style="font-style: italics;">Please provide a valid component name as the first argument when calling this method.</span>
+		</p>
+	</cfif>
+</cfoutput>


### PR DESCRIPTION
### CBWire Application Helper : wireGenericView()

Have you ever found that you end up with a plethora of ColdBox views that contain nothing more than this:

```
<cfoutput>
    <h1>My Page/Wire Title</h1>
    #wire( "myCoolWire" )#
</cfoutput>
```

If you have, you know how it can clutter up your views folder with very generic ColdBox views. The `wireGenericView()` application helper bypasses the need to create these very generic views and sets the view in your handler for you to a generic view from the CBWire module! When used you do not need to call `event.setView()` in your handler.

Method Signature:

```
/**
 * A helper function to set up the view arguments and call the generic wire view.
 * Eliminates the need to manually create a basic view that would usually only contains a
 * title (optional) and the wire() method call with the appropriate arguments.
 *
 * @wireName string | The name of the wire component to render. Required.
 * @wireParams struct | The parameters to pass to the wire component. Optional, defaults to an empty struct.
 * @viewArgs struct | Additional arguments to pass to the view. Optional, defaults to an empty struct.
 * @viewArgs.title string | An optional title to display above the wire component in the view. { "title" : "My Cool Page Title" }
 * @viewArgs.titleTag string | An optional HTML tag to wrap the title in. Defaults to h1 if title is provided without a titleTag. { "titleTag" : "h2" }
 *
 * @return void | Sets the events view to the generic wire view with the appropriate arguments.
 */
function wireGenericView( required string wireName, struct wireParams = {}, struct viewArgs={} );
```

Usage Examples:

Simple use in your handler:

```
// Handler Method
function viewUsers( event, rc, prc ){
    wireGenericView( "users.viewAll" );
}
```

Pass params to the wire() function:

```
// Handler Method
function viewUsers( event, rc, prc ){
    wireGenericView( "users.viewAll", { "inactive" : false } );
}
```

This will the pass the `wireParams` argument struct into the `wire()` methods `params` argument for you.

Set a custom title in the view & pass wire params:

```
// Handler Method
function viewUsers( event, rc, prc ){
    wireGenericView( 
    	"users.viewAll",
    	{ "inactive" : false },
    	{ "title" : "All Active User Accounts" }
    );
}
```

Set custom title in the view using a title tag other other the default H1 and pass wire params:

```
// Handler Method
function viewUsers( event, rc, prc ){
    wireGenericView( 
    	"users.viewAll",
    	{ "inactive" : false }, 
    	{ "title" : "All Active User Accounts", "titleTag" : "h5" } 
    );
}
```

It is a small addition and does not suite every situation. However, when it does suit the situation it can help to improve the organization and manageability of your views folder.